### PR TITLE
Stomp Client Version 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+sudo: false
 php:
   - "5.4"
   - "5.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
 sudo: false
 php:
+  - "7.0"
+  - "5.6"
+  - "5.5"
   - "5.4"
   - "5.3"
 jdk:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,12 @@ Changelog stomp-php
 2.2.4
 -----
 - fixed possible nullpointer on broken connections
+
+3.0.0
+-----
+- This version aims to cover all current forks from https://github.com/dejanb/stomp-php.
+- moved to namespace `Stomp`
+- changed back to `fgets` (https://github.com/dejanb/stomp-php/pull/22)
+- upated travis-ci config
+- merged unit tests for `Stomp\Frame` (https://github.com/chuhlomin/stomp-php/)
+- use stream_socket_client (https://github.com/dejanb/stomp-php/pull/25)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2005-2006 The Apache Software Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 A simple PHP [Stomp](http://stomp.github.com) Client
 
-[![Build Status](https://travis-ci.org/fin-sn-de/stomp-php.svg?branch=master)](https://travis-ci.org/fin-sn-de/stomp-php)
+[![Build Status](https://travis-ci.org/stomp-php/stomp-php.svg?branch=master)](https://travis-ci.org/stomp-php/stomp-php)
 
 Version choice
 --------------
@@ -16,14 +16,14 @@ composer.json
  "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/jh-ism-online-webmaster/stomp-php"
+            "url": "https://github.com/stomp-php/stomp-php"
         }
     ]
 ```
 
 ```json
     "require": {
-        "jh-ism-online-webmaster/stomp-php": "2.2.2"
+        "stomp-php/stomp-php": "2.2.2"
     },
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ A simple PHP [Stomp](http://stomp.github.com) Client
 Version choice
 --------------
 This fork is not compatible to the original stomp from https://github.com/dejanb/stomp-php.
-This is caused since the original fork is mostly outdated. The last compatible version is 2.2.2.
+The last compatible version is 2.2.2.
+The last php-5.3 compatible version is 3.0.0.
+
 
 Installing
 ----------
@@ -23,7 +25,7 @@ composer.json
 
 ```json
     "require": {
-        "stomp-php/stomp-php": "2.2.2"
+        "stomp-php/stomp-php": "3.0.0"
     },
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "fusesource/stomp-php",
+    "name": "stomp-php/stomp-php",
     "description": "stomp support for PHP",
-    "keywords": ["messaging", "stomp", "jms", "activemq"],
-    "homepage": "http://github.com/dejanb/stomp-php",
+    "keywords": ["messaging", "stomp", "jms", "activemq", "rabbitmq"],
+    "homepage": "http://github.com/stomp-php/stomp-php",
     "license": "Apache-2.0",
     "authors": [
         {
@@ -20,8 +20,8 @@
         "php": ">=5.3.0"
     },
     "autoload": {
-        "psr-0": {
-            "FuseSource": "src/"
+        "psr-4": {
+            "Stomp\\": "src/Stomp/"
         }
     }
 }

--- a/examples/binary.php
+++ b/examples/binary.php
@@ -19,8 +19,8 @@ require __DIR__.'/../vendor/autoload.php';
  */
 
 // include a library
-use FuseSource\Stomp\Stomp;
-use FuseSource\Stomp\Message\Bytes;
+use Stomp\Stomp;
+use Stomp\Message\Bytes;
 // make a connection
 $con = new Stomp("tcp://localhost:61613");
 // connect

--- a/examples/connectivity.php
+++ b/examples/connectivity.php
@@ -26,7 +26,7 @@ require __DIR__.'/../vendor/autoload.php';
 */
 // include a library
 
-use FuseSource\Stomp\Stomp;
+use Stomp\Stomp;
 // make a connection
 $con = new Stomp("failover://(tcp://localhost:61614,ssl://localhost:61612)?randomize=false");
 // connect

--- a/examples/durable.php
+++ b/examples/durable.php
@@ -20,7 +20,7 @@ require __DIR__.'/../vendor/autoload.php';
 
 // include a library
 
-use FuseSource\Stomp\Stomp;
+use Stomp\Stomp;
 
 // create a producer
 $producer = new Stomp("tcp://localhost:61613");

--- a/examples/first.php
+++ b/examples/first.php
@@ -20,7 +20,7 @@ require __DIR__.'/../vendor/autoload.php';
 
 // include a library
 
-use FuseSource\Stomp\Stomp;
+use Stomp\Stomp;
 // make a connection
 $opts = array(
     'ssl' => array(

--- a/examples/security.php
+++ b/examples/security.php
@@ -25,8 +25,8 @@ require __DIR__.'/../vendor/autoload.php';
  $ php security.php
 */
 // include a library
-use FuseSource\Stomp\Stomp;
-use FuseSource\Stomp\Exception\StompException;
+use Stomp\Stomp;
+use Stomp\Exception\StompException;
 
 // make a connection
 $con = new Stomp("tcp://localhost:61613");

--- a/examples/transactions.php
+++ b/examples/transactions.php
@@ -19,7 +19,7 @@ require __DIR__.'/../vendor/autoload.php';
  */
 
 // include a library
-use FuseSource\Stomp\Stomp;
+use Stomp\Stomp;
 // make a connection
 $con = new Stomp("tcp://localhost:61613");
 // connect

--- a/examples/transformation.php
+++ b/examples/transformation.php
@@ -19,8 +19,8 @@ require __DIR__.'/../vendor/autoload.php';
  */
 
 // include a library
-use FuseSource\Stomp\Stomp;
-use FuseSource\Stomp\Message\Map;
+use Stomp\Stomp;
+use Stomp\Message\Map;
 // make a connection
 $con = new Stomp("tcp://localhost:61613");
 // connect

--- a/src/FuseSource/Stomp/Connection.php
+++ b/src/FuseSource/Stomp/Connection.php
@@ -292,7 +292,7 @@ class Connection
         }
 
         do {
-            $read = @fread($this->_connection, 1024);
+            $read = @fgets($this->_connection, 1024);
             if ($read === false || $read === '') {
                 throw new ConnectionException('Was not possible to read data from stream.', $this->_activeHost);
             }

--- a/src/Stomp/Connection.php
+++ b/src/Stomp/Connection.php
@@ -1,25 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp;
 
 use Stomp\Exception\ConnectionException;
 use Stomp\Exception\ErrorFrameException;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Connection.php
+++ b/src/Stomp/Connection.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace FuseSource\Stomp;
+namespace Stomp;
 
-use FuseSource\Stomp\Exception\ConnectionException;
-use FuseSource\Stomp\Exception\ErrorFrameException;
+use Stomp\Exception\ConnectionException;
+use Stomp\Exception\ErrorFrameException;
 /**
  *
  * Copyright 2005-2006 The Apache Software Foundation

--- a/src/Stomp/Exception/ConnectionException.php
+++ b/src/Stomp/Exception/ConnectionException.php
@@ -1,22 +1,13 @@
 <?php
-namespace Stomp\Exception;
 
-/**
+/*
+ * This file is part of the Stomp package.
  *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
+
+namespace Stomp\Exception;
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Exception/ConnectionException.php
+++ b/src/Stomp/Exception/ConnectionException.php
@@ -1,5 +1,5 @@
 <?php
-namespace FuseSource\Stomp\Exception;
+namespace Stomp\Exception;
 
 /**
  *

--- a/src/Stomp/Exception/ErrorFrameException.php
+++ b/src/Stomp/Exception/ErrorFrameException.php
@@ -1,7 +1,7 @@
 <?php
-namespace FuseSource\Stomp\Exception;
+namespace Stomp\Exception;
 
-use FuseSource\Stomp\Frame;
+use Stomp\Frame;
 
 /**
  *
@@ -23,13 +23,13 @@ use FuseSource\Stomp\Frame;
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**
- * Exception that occurs, when a frame / response was received that was not expected at this moment.
+ * Stomp server send us an error frame.
  *
  *
  * @package Stomp
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class UnexpectedResponseException extends StompException
+class ErrorFrameException extends StompException
 {
     /**
      *
@@ -40,12 +40,13 @@ class UnexpectedResponseException extends StompException
     /**
      *
      * @param Frame $frame
-     * @param string $expectedInfo
      */
-    function __construct(Frame $frame, $expectedInfo)
+    function __construct(Frame $frame)
     {
         $this->_frame = $frame;
-        parent::__construct(sprintf('Unexpected response received. %s', $expectedInfo));
+        parent::__construct(
+            sprintf('Error "%s"', $frame->headers['message'])
+        );
     }
 
     /**
@@ -56,5 +57,4 @@ class UnexpectedResponseException extends StompException
     {
         return $this->_frame;
     }
-
 }

--- a/src/Stomp/Exception/ErrorFrameException.php
+++ b/src/Stomp/Exception/ErrorFrameException.php
@@ -1,24 +1,15 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Exception;
 
 use Stomp\Frame;
-
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Exception/MissingReceiptException.php
+++ b/src/Stomp/Exception/MissingReceiptException.php
@@ -1,7 +1,7 @@
 <?php
-namespace FuseSource\Stomp\Exception;
+namespace Stomp\Exception;
 
-use FuseSource\Stomp\Frame;
+use Stomp\Frame;
 
 /**
  *

--- a/src/Stomp/Exception/MissingReceiptException.php
+++ b/src/Stomp/Exception/MissingReceiptException.php
@@ -1,24 +1,15 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Exception;
 
 use Stomp\Frame;
-
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Exception/StompException.php
+++ b/src/Stomp/Exception/StompException.php
@@ -1,23 +1,15 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Exception;
 
 use Exception;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Exception/StompException.php
+++ b/src/Stomp/Exception/StompException.php
@@ -1,7 +1,7 @@
 <?php
-namespace FuseSource\Stomp\Message;
+namespace Stomp\Exception;
 
-use FuseSource\Stomp\Frame;
+use Exception;
 /**
  *
  * Copyright 2005-2006 The Apache Software Foundation
@@ -21,31 +21,22 @@ use FuseSource\Stomp\Frame;
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
-
 /**
- * Message that contains a set of name-value pairs
+ * Base exception for all special stomp exceptions.
  *
  * @package Stomp
  */
-class Map extends Frame
+class StompException extends Exception
 {
-    public $map;
 
     /**
-     * Constructor
+     * Stomp server error details
      *
-     * @param Frame|string $msg
-     * @param array $headers
+     * @deprecated use getMessage()
+     * @return string
      */
-    function __construct ($msg, array $headers = array())
+    public function getDetails()
     {
-        if ($msg instanceof Frame) {
-            parent::__construct($msg->command, $msg->headers, $msg->body);
-            $this->map = json_decode($msg->body, true);
-        } else {
-            parent::__construct("SEND", $headers, $msg);
-            $this->headers['transformation'] = 'jms-map-json';
-            $this->body = json_encode($msg);
-        }
+        return $this->getMessage();
     }
 }

--- a/src/Stomp/Exception/UnexpectedResponseException.php
+++ b/src/Stomp/Exception/UnexpectedResponseException.php
@@ -1,24 +1,15 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Exception;
 
 use Stomp\Frame;
-
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Exception/UnexpectedResponseException.php
+++ b/src/Stomp/Exception/UnexpectedResponseException.php
@@ -1,7 +1,8 @@
 <?php
-namespace FuseSource\Stomp\Exception;
+namespace Stomp\Exception;
 
-use Exception;
+use Stomp\Frame;
+
 /**
  *
  * Copyright 2005-2006 The Apache Software Foundation
@@ -22,21 +23,38 @@ use Exception;
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**
- * Base exception for all special stomp exceptions.
+ * Exception that occurs, when a frame / response was received that was not expected at this moment.
+ *
  *
  * @package Stomp
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class StompException extends Exception
+class UnexpectedResponseException extends StompException
 {
+    /**
+     *
+     * @var Frame
+     */
+    private $_frame;
 
     /**
-     * Stomp server error details
      *
-     * @deprecated use getMessage()
-     * @return string
+     * @param Frame $frame
+     * @param string $expectedInfo
      */
-    public function getDetails()
+    function __construct(Frame $frame, $expectedInfo)
     {
-        return $this->getMessage();
+        $this->_frame = $frame;
+        parent::__construct(sprintf('Unexpected response received. %s', $expectedInfo));
     }
+
+    /**
+     *
+     * @return Frame
+     */
+    public function getFrame()
+    {
+        return $this->_frame;
+    }
+
 }

--- a/src/Stomp/Frame.php
+++ b/src/Stomp/Frame.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace FuseSource\Stomp;
+namespace Stomp;
 
-use FuseSource\Stomp\Exception\StompException;
+use Stomp\Exception\StompException;
 /**
  *
  * Copyright 2005-2006 The Apache Software Foundation

--- a/src/Stomp/Frame.php
+++ b/src/Stomp/Frame.php
@@ -1,24 +1,15 @@
 <?php
 
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp;
 
 use Stomp\Exception\StompException;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Message.php
+++ b/src/Stomp/Message.php
@@ -1,21 +1,13 @@
 <?php
-namespace Stomp;
-/**
+
+/*
+ * This file is part of the Stomp package.
  *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
+
+namespace Stomp;
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Message.php
+++ b/src/Stomp/Message.php
@@ -1,5 +1,5 @@
 <?php
-namespace FuseSource\Stomp;
+namespace Stomp;
 /**
  *
  * Copyright 2005-2006 The Apache Software Foundation

--- a/src/Stomp/Message/Bytes.php
+++ b/src/Stomp/Message/Bytes.php
@@ -1,24 +1,15 @@
 <?php
 
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Message;
 
 use Stomp\Message;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Message/Bytes.php
+++ b/src/Stomp/Message/Bytes.php
@@ -1,8 +1,8 @@
 <?php
-namespace FuseSource\Stomp\Exception;
 
-use FuseSource\Stomp\Frame;
+namespace Stomp\Message;
 
+use Stomp\Message;
 /**
  *
  * Copyright 2005-2006 The Apache Software Foundation
@@ -23,38 +23,21 @@ use FuseSource\Stomp\Frame;
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**
- * Stomp server send us an error frame.
- *
+ * Message that contains a stream of uninterpreted bytes
  *
  * @package Stomp
- * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class ErrorFrameException extends StompException
+class Bytes extends Message
 {
     /**
+     * Constructor
      *
-     * @var Frame
+     * @param string $body
+     * @param array $headers
      */
-    private $_frame;
-
-    /**
-     *
-     * @param Frame $frame
-     */
-    function __construct(Frame $frame)
+    function __construct ($body, array $headers = array())
     {
-        $this->_frame = $frame;
-        parent::__construct(
-            sprintf('Error "%s"', $frame->headers['message'])
-        );
-    }
-
-    /**
-     *
-     * @return Frame
-     */
-    public function getFrame()
-    {
-        return $this->_frame;
+        parent::__construct($body, $headers);
+        $this->headers['content-length'] = count(unpack("c*", $body));
     }
 }

--- a/src/Stomp/Message/Map.php
+++ b/src/Stomp/Message/Map.php
@@ -1,23 +1,15 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Message;
 
 use Stomp\Frame;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Message/Map.php
+++ b/src/Stomp/Message/Map.php
@@ -1,8 +1,7 @@
 <?php
+namespace Stomp\Message;
 
-namespace FuseSource\Stomp\Message;
-
-use FuseSource\Stomp\Message;
+use Stomp\Frame;
 /**
  *
  * Copyright 2005-2006 The Apache Software Foundation
@@ -22,22 +21,31 @@ use FuseSource\Stomp\Message;
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
+
 /**
- * Message that contains a stream of uninterpreted bytes
+ * Message that contains a set of name-value pairs
  *
  * @package Stomp
  */
-class Bytes extends Message
+class Map extends Frame
 {
+    public $map;
+
     /**
      * Constructor
      *
-     * @param string $body
+     * @param Frame|string $msg
      * @param array $headers
      */
-    function __construct ($body, array $headers = array())
+    function __construct ($msg, array $headers = array())
     {
-        parent::__construct($body, $headers);
-        $this->headers['content-length'] = count(unpack("c*", $body));
+        if ($msg instanceof Frame) {
+            parent::__construct($msg->command, $msg->headers, $msg->body);
+            $this->map = json_decode($msg->body, true);
+        } else {
+            parent::__construct("SEND", $headers, $msg);
+            $this->headers['transformation'] = 'jms-map-json';
+            $this->body = json_encode($msg);
+        }
     }
 }

--- a/src/Stomp/Parser.php
+++ b/src/Stomp/Parser.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace FuseSource\Stomp;
+namespace Stomp;
 
-use FuseSource\Stomp\Message\Map;
+use Stomp\Message\Map;
 /**
  *
  * Copyright 2005-2006 The Apache Software Foundation

--- a/src/Stomp/Parser.php
+++ b/src/Stomp/Parser.php
@@ -1,24 +1,15 @@
 <?php
 
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp;
 
 use Stomp\Message\Map;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Protocol.php
+++ b/src/Stomp/Protocol.php
@@ -1,23 +1,13 @@
 <?php
 
-namespace Stomp;
-
-/**
+/*
+ * This file is part of the Stomp package.
  *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
+
+namespace Stomp;
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Protocol.php
+++ b/src/Stomp/Protocol.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace FuseSource\Stomp;
+namespace Stomp;
 
 /**
  *

--- a/src/Stomp/Protocol/ActiveMq.php
+++ b/src/Stomp/Protocol/ActiveMq.php
@@ -1,26 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Protocol;
 
 use Stomp\Frame;
 use Stomp\Protocol;
-
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Protocol/ActiveMq.php
+++ b/src/Stomp/Protocol/ActiveMq.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace FuseSource\Stomp\Protocol;
+namespace Stomp\Protocol;
 
-use FuseSource\Stomp\Frame;
-use FuseSource\Stomp\Protocol;
+use Stomp\Frame;
+use Stomp\Protocol;
 
 /**
  *
@@ -25,7 +25,7 @@ use FuseSource\Stomp\Protocol;
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**
- * RabbitMq Stomp dialect.
+ * ActiveMq Stomp dialect.
  *
  *
  * @package Stomp
@@ -34,11 +34,10 @@ use FuseSource\Stomp\Protocol;
  * @author Michael Caplan <mcaplan@labnet.net>
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class RabbitMq extends Protocol
+class ActiveMq extends Protocol
 {
-
     /**
-     * Configure a RabbitMq protocol.
+     * Configure a ActiveMq protocol.
      *
      * @param Protocol $base
      */
@@ -47,41 +46,31 @@ class RabbitMq extends Protocol
         parent::__construct($base->getPrefetchSize(), $base->getClientId());
     }
 
-
     /**
-     * RabbitMq subscribe frame.
+     * ActiveMq subscribe frame.
      *
      * @param string $destination
      * @param array $headers
      * @param boolean $durable durable subscription
      * @return Frame
      */
-    public function getSubscribeFrame ($destination, array $headers = array(), $durable = false)
+    public function getSubscribeFrame($destination, array $headers = array(), $durable = false)
     {
         $frame = parent::getSubscribeFrame($destination, $headers);
-        $frame->setHeader('prefetch-count', $this->getPrefetchSize());
-        $this->addClientId($frame);
+        $frame->setHeader('activemq.prefetchSize', $this->getPrefetchSize());
         if ($durable) {
-            $frame->setHeader('persistent', 'true');
+            $frame->setHeader('activemq.subscriptionName', $this->getClientId());
         }
         return $frame;
     }
 
-    /**
-     * RabbitMq unsubscribe frame.
-     *
-     * @param string $destination
-     * @param array $headers
-     * @param boolean $durable durable subscription
-     * @return Frame
-     */
-    public function getUnsubscribeFrame ($destination, array $headers = array(), $durable = false)
+    public function getUnsubscribeFrame($destination, array $headers = array(), $durable = false)
     {
-        $frame = parent::getUnsubscribeFrame($destination, $headers);
-        $this->addClientId($frame);
-        if ($durable) {
-            $frame->setHeader('persistent', 'true');
+        $frame = parent::getUnsubscribeFrame($destination, $headers, $durable);
+        if ($this->hasClientId() && $durable) {
+            $frame->setHeader('activemq.subscriptionName', $this->getClientId());
         }
         return $frame;
     }
+
 }

--- a/src/Stomp/Protocol/RabbitMq.php
+++ b/src/Stomp/Protocol/RabbitMq.php
@@ -1,26 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Protocol;
 
 use Stomp\Frame;
 use Stomp\Protocol;
-
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/src/Stomp/Protocol/RabbitMq.php
+++ b/src/Stomp/Protocol/RabbitMq.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace FuseSource\Stomp\Protocol;
+namespace Stomp\Protocol;
 
-use FuseSource\Stomp\Frame;
-use FuseSource\Stomp\Protocol;
+use Stomp\Frame;
+use Stomp\Protocol;
 
 /**
  *
@@ -25,7 +25,7 @@ use FuseSource\Stomp\Protocol;
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**
- * ActiveMq Stomp dialect.
+ * RabbitMq Stomp dialect.
  *
  *
  * @package Stomp
@@ -34,10 +34,11 @@ use FuseSource\Stomp\Protocol;
  * @author Michael Caplan <mcaplan@labnet.net>
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class ActiveMq extends Protocol
+class RabbitMq extends Protocol
 {
+
     /**
-     * Configure a ActiveMq protocol.
+     * Configure a RabbitMq protocol.
      *
      * @param Protocol $base
      */
@@ -46,31 +47,41 @@ class ActiveMq extends Protocol
         parent::__construct($base->getPrefetchSize(), $base->getClientId());
     }
 
+
     /**
-     * ActiveMq subscribe frame.
+     * RabbitMq subscribe frame.
      *
      * @param string $destination
      * @param array $headers
      * @param boolean $durable durable subscription
      * @return Frame
      */
-    public function getSubscribeFrame($destination, array $headers = array(), $durable = false)
+    public function getSubscribeFrame ($destination, array $headers = array(), $durable = false)
     {
         $frame = parent::getSubscribeFrame($destination, $headers);
-        $frame->setHeader('activemq.prefetchSize', $this->getPrefetchSize());
+        $frame->setHeader('prefetch-count', $this->getPrefetchSize());
+        $this->addClientId($frame);
         if ($durable) {
-            $frame->setHeader('activemq.subscriptionName', $this->getClientId());
+            $frame->setHeader('persistent', 'true');
         }
         return $frame;
     }
 
-    public function getUnsubscribeFrame($destination, array $headers = array(), $durable = false)
+    /**
+     * RabbitMq unsubscribe frame.
+     *
+     * @param string $destination
+     * @param array $headers
+     * @param boolean $durable durable subscription
+     * @return Frame
+     */
+    public function getUnsubscribeFrame ($destination, array $headers = array(), $durable = false)
     {
-        $frame = parent::getUnsubscribeFrame($destination, $headers, $durable);
-        if ($this->hasClientId() && $durable) {
-            $frame->setHeader('activemq.subscriptionName', $this->getClientId());
+        $frame = parent::getUnsubscribeFrame($destination, $headers);
+        $this->addClientId($frame);
+        if ($durable) {
+            $frame->setHeader('persistent', 'true');
         }
         return $frame;
     }
-
 }

--- a/src/Stomp/Stomp.php
+++ b/src/Stomp/Stomp.php
@@ -97,15 +97,31 @@ class Stomp
     private $_receiptWait = 2;
 
     /**
+     *
+     * @var string
+     */
+    private $_login = null;
+
+    /**
+     *
+     * @var string
+     */
+    private $_passcode = null;
+
+    /**
      * Constructor
      *
      * @param string|Connection $broker Broker URL or a connection
+     * @param string $login
+     * @param string $passcode
      * @throws StompException
      * @see Connection::__construct()
      */
-    public function __construct ($broker)
+    public function __construct ($broker, $login = null, $passcode = null)
     {
         $this->_connection = $broker instanceof Connection ? $broker : new Connection($broker);
+        $this->_login = $login;
+        $this->_passcode = $passcode;
     }
 
     /**
@@ -116,11 +132,17 @@ class Stomp
      * @return boolean
      * @throws StompException
      */
-    public function connect ($login = '', $passcode = '')
+    public function connect ($login = null, $passcode = null)
     {
+        if ($login !== null) {
+            $this->_login = $login;
+        }
+        if ($passcode !== null) {
+            $this->_passcode = $passcode;
+        }
         $this->_connection->connect();
         $this->_protocol = new Protocol($this->prefetchSize, $this->clientId);
-        $this->sendFrame($this->_protocol->getConnectFrame($login, $passcode), false);
+        $this->sendFrame($this->_protocol->getConnectFrame($this->_login, $this->_passcode), false);
         if ($frame = $this->_connection->readFrame()) {
             if ($frame->command != 'CONNECTED') {
                 throw new UnexpectedResponseException($frame, 'Expected a CONNECTED Frame!');

--- a/src/Stomp/Stomp.php
+++ b/src/Stomp/Stomp.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace FuseSource\Stomp;
+namespace Stomp;
 
-use FuseSource\Stomp\Exception\ConnectionException;
-use FuseSource\Stomp\Exception\MissingReceiptException;
-use FuseSource\Stomp\Exception\StompException;
-use FuseSource\Stomp\Exception\UnexpectedResponseException;
-use FuseSource\Stomp\Protocol\ActiveMq;
-use FuseSource\Stomp\Protocol\RabbitMq;
+use Stomp\Exception\ConnectionException;
+use Stomp\Exception\MissingReceiptException;
+use Stomp\Exception\StompException;
+use Stomp\Exception\UnexpectedResponseException;
+use Stomp\Protocol\ActiveMq;
+use Stomp\Protocol\RabbitMq;
 
 /**
  *

--- a/src/Stomp/Stomp.php
+++ b/src/Stomp/Stomp.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp;
 
 use Stomp\Exception\ConnectionException;
@@ -8,23 +15,6 @@ use Stomp\Exception\StompException;
 use Stomp\Exception\UnexpectedResponseException;
 use Stomp\Protocol\ActiveMq;
 use Stomp\Protocol\RabbitMq;
-
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -157,39 +157,5 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
         }
     }
 
-    function testConnectionWillReturnBufferedFramesIfMoreThanOneWasReturnedInLastRead()
-    {
-        $connection = $this->getMockBuilder('\FuseSource\Stomp\Connection')
-            ->setMethods(array('hasDataToRead', '_connect'))
-            ->setConstructorArgs(array('tcp://host'))
-            ->getMock();
-
-        $fp = tmpfile();
-
-        fwrite($fp, "INFO\nmsgno:1\n\nbody1\x00" . PHP_EOL);
-        fwrite($fp, "INFO\nmsgno:22\n\nbody22\x00");
-        fwrite($fp, "INFO\nmsgno:333\n\nbody333\x00" . PHP_EOL);
-        fwrite($fp, "INFO\nmsgno:4\n\nbody\x00");
-        fseek($fp, 0);
-
-        $connection->expects($this->once())->method('_connect')->will($this->returnValue($fp));
-        $connection->expects($this->once())->method('hasDataToRead')->will($this->returnValue(true));
-
-        $connection->connect();
-
-        $firstFrame = $connection->readFrame();
-        fclose($fp);
-
-        // even if connection is closed, there must be known frames...
-        $secondFrame = $connection->readFrame();
-        $thirdFrame = $connection->readFrame();
-        $fourthFrame = $connection->readFrame();
-
-        $this->assertEquals('body1', $firstFrame->body);
-        $this->assertEquals('body22', $secondFrame->body);
-        $this->assertEquals('body333', $thirdFrame->body);
-        $this->assertEquals('body', $fourthFrame->body);
-    }
-
 }
 

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace FuseSource\Tests\Functional;
+namespace Stomp\Tests\Functional;
 
-use FuseSource\Stomp\Connection;
-use FuseSource\Stomp\Exception\ConnectionException;
-use FuseSource\Stomp\Exception\ErrorFrameException;
-use FuseSource\Stomp\Frame;
+use Stomp\Connection;
+use Stomp\Exception\ConnectionException;
+use Stomp\Exception\ErrorFrameException;
+use Stomp\Frame;
 use PHPUnit_Framework_TestCase;
 /**
  *
@@ -34,7 +34,7 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
 {
     function testReadFrameThrowsExceptionIfStreamIsBroken()
     {
-        $connection = $this->getMockBuilder('\FuseSource\Stomp\Connection')
+        $connection = $this->getMockBuilder('\Stomp\Connection')
             ->setMethods(array('hasDataToRead', '_connect'))
             ->setConstructorArgs(array('tcp://host'))
             ->getMock();
@@ -56,7 +56,7 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
 
     function testReadFrameThrowsExceptionIfErrorFrameIsReceived()
     {
-        $connection = $this->getMockBuilder('\FuseSource\Stomp\Connection')
+        $connection = $this->getMockBuilder('\Stomp\Connection')
             ->setMethods(array('hasDataToRead', '_connect'))
             ->setConstructorArgs(array('tcp://host'))
             ->getMock();
@@ -83,7 +83,7 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
 
     function testWriteFrameThrowsExceptionIfConnectionIsBroken()
     {
-        $connection = $this->getMockBuilder('\FuseSource\Stomp\Connection')
+        $connection = $this->getMockBuilder('\Stomp\Connection')
             ->setMethods(array('_connect'))
             ->setConstructorArgs(array('tcp://host'))
             ->getMock();
@@ -108,7 +108,7 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
 
     function testHasDataToReadThrowsExceptionIfConnectionIsBroken()
     {
-        $connection = $this->getMockBuilder('\FuseSource\Stomp\Connection')
+        $connection = $this->getMockBuilder('\Stomp\Connection')
             ->setMethods(array('isConnected', '_connect'))
             ->setConstructorArgs(array('tcp://host'))
             ->getMock();
@@ -148,7 +148,7 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
         } catch (ConnectionException $ex) {
             $this->assertContains('Could not connect to a broker', $ex->getMessage());
 
-            $this->assertInstanceOf('FuseSource\Stomp\Exception\ConnectionException', $ex->getPrevious(), 'There should be a previous exception.');
+            $this->assertInstanceOf('Stomp\Exception\ConnectionException', $ex->getPrevious(), 'There should be a previous exception.');
             $prev = $ex->getPrevious();
             $hostinfo = $prev->getConnectionInfo();
             $this->assertEquals('0.0.0.1', $hostinfo['host']);

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Tests\Functional;
 
 use Stomp\Connection;
@@ -7,22 +14,7 @@ use Stomp\Exception\ConnectionException;
 use Stomp\Exception\ErrorFrameException;
 use Stomp\Frame;
 use PHPUnit_Framework_TestCase;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**

--- a/tests/Functional/StompASyncTest.php
+++ b/tests/Functional/StompASyncTest.php
@@ -1,4 +1,12 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Tests\Functional;
 
 use Stomp\Stomp;

--- a/tests/Functional/StompASyncTest.php
+++ b/tests/Functional/StompASyncTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace FuseSource\Tests\Functional;
+namespace Stomp\Tests\Functional;
 
-use FuseSource\Stomp\Stomp;
+use Stomp\Stomp;
 use PHPUnit_Framework_TestCase;
 
 /**

--- a/tests/Functional/StompFailoverTest.php
+++ b/tests/Functional/StompFailoverTest.php
@@ -1,24 +1,17 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Tests\Functional;
 
 use Stomp\Stomp;
 use PHPUnit_Framework_TestCase;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**

--- a/tests/Functional/StompFailoverTest.php
+++ b/tests/Functional/StompFailoverTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace FuseSource\Tests\Functional;
+namespace Stomp\Tests\Functional;
 
-use FuseSource\Stomp\Stomp;
+use Stomp\Stomp;
 use PHPUnit_Framework_TestCase;
 /**
  *

--- a/tests/Functional/StompRabbitTest.php
+++ b/tests/Functional/StompRabbitTest.php
@@ -1,9 +1,9 @@
 <?php
-namespace FuseSource\Tests\Functional;
+namespace Stomp\Tests\Functional;
 
-use FuseSource\Stomp\Message\Bytes;
-use FuseSource\Stomp\Message\Map;
-use FuseSource\Stomp\Stomp;
+use Stomp\Message\Bytes;
+use Stomp\Message\Map;
+use Stomp\Stomp;
 use PHPUnit_Framework_TestCase;
 /**
  *
@@ -84,7 +84,7 @@ class StompRabbitTest extends PHPUnit_Framework_TestCase
 
         $frame = $this->Stomp->readFrame();
 
-        $this->assertTrue($frame instanceof \Fusesource\Stomp\Frame, 'Frame expected');
+        $this->assertTrue($frame instanceof \Stomp\Frame, 'Frame expected');
 
         $this->Stomp->ack($frame);
 
@@ -118,7 +118,7 @@ class StompRabbitTest extends PHPUnit_Framework_TestCase
 
             for ($x = $y; $x < $y + 10; ++$x) {
                 $frame = $this->Stomp->readFrame();
-                $this->assertTrue($frame instanceof \Fusesource\Stomp\Frame);
+                $this->assertTrue($frame instanceof \Stomp\Frame);
                 $this->assertArrayHasKey($frame->body, $messages, $frame->body . ' is not in the list of messages to ack');
                 $this->assertEquals('sent', $messages[$frame->body], $frame->body . ' has been marked acked, but has been received again.');
                 $messages[$frame->body] = 'acked';
@@ -212,7 +212,7 @@ class StompRabbitTest extends PHPUnit_Framework_TestCase
         $this->Stomp->send($this->queue, 'testReadFrame');
         $this->Stomp->subscribe($this->queue);
         $frame = $this->Stomp->readFrame();
-        $this->assertTrue($frame instanceof \Fusesource\Stomp\Frame);
+        $this->assertTrue($frame instanceof \Stomp\Frame);
         $this->assertEquals('testReadFrame', $frame->body, 'Body of test frame does not match sent message');
         $this->Stomp->ack($frame);
         $this->Stomp->unsubscribe($this->queue);
@@ -228,7 +228,7 @@ class StompRabbitTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->Stomp->send($this->queue, 'testSend'));
         $this->Stomp->subscribe($this->queue);
         $frame = $this->Stomp->readFrame();
-        $this->assertTrue($frame instanceof \Fusesource\Stomp\Frame);
+        $this->assertTrue($frame instanceof \Stomp\Frame);
         $this->assertEquals('testSend', $frame->body, 'Body of test frame does not match sent message');
         $this->Stomp->ack($frame);
         $this->Stomp->unsubscribe($this->queue);
@@ -261,7 +261,7 @@ class StompRabbitTest extends PHPUnit_Framework_TestCase
 
         $this->Stomp->subscribe($this->queue, array('transformation' => 'jms-map-json'));
         $msg = $this->Stomp->readFrame();
-        $this->assertTrue($msg instanceOf \Fusesource\Stomp\Message\Map);
+        $this->assertTrue($msg instanceOf \Stomp\Message\Map);
         $this->assertEquals($msg->map, $body);
         $this->Stomp->ack($msg);
         $this->Stomp->disconnect();

--- a/tests/Functional/StompRabbitTest.php
+++ b/tests/Functional/StompRabbitTest.php
@@ -1,26 +1,19 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Tests\Functional;
 
 use Stomp\Message\Bytes;
 use Stomp\Message\Map;
 use Stomp\Stomp;
 use PHPUnit_Framework_TestCase;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**

--- a/tests/Functional/StompSyncTest.php
+++ b/tests/Functional/StompSyncTest.php
@@ -1,4 +1,12 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Tests\Functional;
 
 use Stomp\Stomp;

--- a/tests/Functional/StompSyncTest.php
+++ b/tests/Functional/StompSyncTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace FuseSource\Tests\Functional;
+namespace Stomp\Tests\Functional;
 
-use FuseSource\Stomp\Stomp;
+use Stomp\Stomp;
 use PHPUnit_Framework_TestCase;
 
 /**

--- a/tests/Functional/StompTest.php
+++ b/tests/Functional/StompTest.php
@@ -1,27 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Tests\Functional;
 
 use Stomp\Message\Bytes;
 use Stomp\Message\Map;
 use Stomp\Stomp;
 use PHPUnit_Framework_TestCase;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**

--- a/tests/Functional/StompTest.php
+++ b/tests/Functional/StompTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace FuseSource\Tests\Functional;
+namespace Stomp\Tests\Functional;
 
-use FuseSource\Stomp\Message\Bytes;
-use FuseSource\Stomp\Message\Map;
-use FuseSource\Stomp\Stomp;
+use Stomp\Message\Bytes;
+use Stomp\Message\Map;
+use Stomp\Stomp;
 use PHPUnit_Framework_TestCase;
 /**
  *
@@ -81,7 +81,7 @@ class StompTest extends PHPUnit_Framework_TestCase
 
         $frame = $this->Stomp->readFrame();
 
-        $this->assertTrue($frame instanceof \Fusesource\Stomp\Frame, 'Frame expected');
+        $this->assertTrue($frame instanceof \Stomp\Frame, 'Frame expected');
 
         $this->Stomp->ack($frame);
 
@@ -115,7 +115,7 @@ class StompTest extends PHPUnit_Framework_TestCase
 
             for ($x = $y; $x < $y + 10; ++$x) {
                 $frame = $this->Stomp->readFrame();
-                $this->assertTrue($frame instanceof \Fusesource\Stomp\Frame);
+                $this->assertTrue($frame instanceof \Stomp\Frame);
                 $this->assertArrayHasKey($frame->body, $messages, $frame->body . ' is not in the list of messages to ack');
                 $this->assertEquals('sent', $messages[$frame->body], $frame->body . ' has been marked acked, but has been received again.');
                 $messages[$frame->body] = 'acked';
@@ -209,7 +209,7 @@ class StompTest extends PHPUnit_Framework_TestCase
         $this->Stomp->send($this->queue, 'testReadFrame');
         $this->Stomp->subscribe($this->queue);
         $frame = $this->Stomp->readFrame();
-        $this->assertTrue($frame instanceof \Fusesource\Stomp\Frame);
+        $this->assertTrue($frame instanceof \Stomp\Frame);
         $this->assertEquals('testReadFrame', $frame->body, 'Body of test frame does not match sent message');
         $this->Stomp->ack($frame);
         $this->Stomp->unsubscribe($this->queue);
@@ -225,7 +225,7 @@ class StompTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->Stomp->send($this->queue, 'testSend'));
         $this->Stomp->subscribe($this->queue);
         $frame = $this->Stomp->readFrame();
-        $this->assertTrue($frame instanceof \Fusesource\Stomp\Frame);
+        $this->assertTrue($frame instanceof \Stomp\Frame);
         $this->assertEquals('testSend', $frame->body, 'Body of test frame does not match sent message');
         $this->Stomp->ack($frame);
         $this->Stomp->unsubscribe($this->queue);
@@ -258,7 +258,7 @@ class StompTest extends PHPUnit_Framework_TestCase
 
         $this->Stomp->subscribe($this->queue, array('transformation' => 'jms-map-json'));
         $msg = $this->Stomp->readFrame();
-        $this->assertTrue($msg instanceOf \Fusesource\Stomp\Message\Map);
+        $this->assertTrue($msg instanceOf \Stomp\Message\Map);
         $this->assertEquals($msg->map, $body);
         $this->Stomp->ack($msg);
         $this->Stomp->disconnect();

--- a/tests/Unit/Stomp/ConnectionTest.php
+++ b/tests/Unit/Stomp/ConnectionTest.php
@@ -1,4 +1,12 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Tests\Unit\Stomp;
 
 use Exception;
@@ -6,22 +14,7 @@ use Stomp\Connection;
 use Stomp\Frame;
 use PHPUnit_Framework_TestCase;
 use ReflectionMethod;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**

--- a/tests/Unit/Stomp/ConnectionTest.php
+++ b/tests/Unit/Stomp/ConnectionTest.php
@@ -1,9 +1,9 @@
 <?php
-namespace FuseSource\Tests\Unit\Stomp;
+namespace Stomp\Tests\Unit\Stomp;
 
 use Exception;
-use FuseSource\Stomp\Connection;
-use FuseSource\Stomp\Frame;
+use Stomp\Connection;
+use Stomp\Frame;
 use PHPUnit_Framework_TestCase;
 use ReflectionMethod;
 /**
@@ -104,7 +104,7 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \FuseSource\Stomp\Exception\StompException
+     * @expectedException \Stomp\Exception\StompException
      */
     public function testBrokerUriParseWithEmptyListWillLeadToException()
     {
@@ -114,7 +114,7 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
 
     public function testConnectionSetupTriesFullHostListBeforeGivingUp()
     {
-        $connection = $this->getMockBuilder('\FuseSource\Stomp\Connection')
+        $connection = $this->getMockBuilder('\Stomp\Connection')
             ->setMethods(array('_connect'))
             ->setConstructorArgs(array('failover://(tcp://host1,tcp://host2,tcp://host3)'))
             ->getMock();
@@ -129,7 +129,7 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
                 function ($host) use (&$expectedHosts, $test) {
                     $current = array_shift($expectedHosts);
                     $test->assertEquals($current, $host['host'], 'Wrong host given to connect.');
-                    throw new \FuseSource\Stomp\Exception\ConnectionException('Connection failed.', $host);
+                    throw new \Stomp\Exception\ConnectionException('Connection failed.', $host);
                 }
             )
         );
@@ -143,7 +143,7 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \FuseSource\Stomp\Exception\StompException
+     * @expectedException \Stomp\Exception\StompException
      */
     public function testHasDataToReadThrowsExceptionIfNotConnected()
     {
@@ -152,7 +152,7 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \FuseSource\Stomp\Exception\StompException
+     * @expectedException \Stomp\Exception\StompException
      */
     public function testReadFrameThrowsExceptionIfNotConnected()
     {
@@ -161,7 +161,7 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \FuseSource\Stomp\Exception\StompException
+     * @expectedException \Stomp\Exception\StompException
      */
     public function testWriteFrameThrowsExceptionIfNotConnected()
     {

--- a/tests/Unit/Stomp/FrameTest.php
+++ b/tests/Unit/Stomp/FrameTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace FuseSource\Tests\Unit\Stomp;
+namespace Stomp\Tests\Unit\Stomp;
 
 
-use FuseSource\Stomp\Frame;
+use Stomp\Frame;
 use PHPUnit_Framework_TestCase;
 
 class FrameTest extends PHPUnit_Framework_TestCase

--- a/tests/Unit/Stomp/FrameTest.php
+++ b/tests/Unit/Stomp/FrameTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Tests\Unit\Stomp;
 
 

--- a/tests/Unit/Stomp/FrameTest.php
+++ b/tests/Unit/Stomp/FrameTest.php
@@ -13,10 +13,10 @@ class FrameTest extends PHPUnit_Framework_TestCase
     {
         $frame = new Frame(
             'SEND',
-            [
+            array(
                 'destination' => '/queue/a',
                 'receipt' => 'message-12345'
-            ],
+            ),
             'hello queue a^@'
         );
 
@@ -58,7 +58,7 @@ hello queue a^@' . "\x00",
     /** @test */
     public function shouldConvertFrameWithoutBodyToString()
     {
-        $frame = new Frame('SEND', ['destination' => '/queue/a']);
+        $frame = new Frame('SEND', array('destination' => '/queue/a'));
 
         $result = $frame->__toString();
         $this->assertEquals(

--- a/tests/Unit/Stomp/FrameTest.php
+++ b/tests/Unit/Stomp/FrameTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace FuseSource\Tests\Unit\Stomp;
+
+
+use FuseSource\Stomp\Frame;
+use PHPUnit_Framework_TestCase;
+
+class FrameTest extends PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function shouldConvertFrameToString()
+    {
+        $frame = new Frame(
+            'SEND',
+            [
+                'destination' => '/queue/a',
+                'receipt' => 'message-12345'
+            ],
+            'hello queue a^@'
+        );
+
+        $result = $frame->__toString();
+        $this->assertEquals(
+            'SEND
+destination:/queue/a
+receipt:message-12345
+
+hello queue a^@' . "\x00",
+            $result
+        );
+    }
+
+    /** @test */
+    public function shouldConvertEmptyFrameToString()
+    {
+        $frame = new Frame();
+
+        $result = $frame->__toString();
+        $this->assertEquals(
+            "\n\n\x00",
+            $result
+        );
+    }
+
+    /** @test */
+    public function shouldConvertFrameWithoutHeadersToString()
+    {
+        $frame = new Frame('SEND', array(), 'hello');
+
+        $result = $frame->__toString();
+        $this->assertEquals(
+            "SEND\n\nhello\x00",
+            $result
+        );
+    }
+
+    /** @test */
+    public function shouldConvertFrameWithoutBodyToString()
+    {
+        $frame = new Frame('SEND', ['destination' => '/queue/a']);
+
+        $result = $frame->__toString();
+        $this->assertEquals(
+            "SEND\ndestination:/queue/a\n\n\x00",
+            $result
+        );
+    }
+}

--- a/tests/Unit/Stomp/ParserTest.php
+++ b/tests/Unit/Stomp/ParserTest.php
@@ -1,24 +1,17 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Tests\Unit\Stomp;
 
 use Stomp\Parser;
 use PHPUnit_Framework_TestCase;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**

--- a/tests/Unit/Stomp/ParserTest.php
+++ b/tests/Unit/Stomp/ParserTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace FuseSource\Tests\Unit\Stomp;
+namespace Stomp\Tests\Unit\Stomp;
 
-use FuseSource\Stomp\Parser;
+use Stomp\Parser;
 use PHPUnit_Framework_TestCase;
 /**
  *
@@ -39,7 +39,7 @@ class ParserTest extends PHPUnit_Framework_TestCase
         $parser->addData($msg);
         $parser->parse();
         $result = $parser->getFrame();
-        $this->assertInstanceOf('\FuseSource\Stomp\Message\Map', $result);
+        $this->assertInstanceOf('\Stomp\Message\Map', $result);
         $this->assertEquals('value', $result->map['var']);
     }
 
@@ -53,7 +53,7 @@ class ParserTest extends PHPUnit_Framework_TestCase
         $parser->parse();
         $result = $parser->getFrame();
 
-        $this->assertInstanceOf('\FuseSource\Stomp\Frame', $result);
+        $this->assertInstanceOf('\Stomp\Frame', $result);
         $this->assertEquals('var', $result->body);
         $this->assertEquals('value1', $result->headers['header1']);
     }

--- a/tests/Unit/Stomp/Protocol/ActiveMqTest.php
+++ b/tests/Unit/Stomp/Protocol/ActiveMqTest.php
@@ -1,25 +1,18 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Tests\Unit\Protocol;
 
 use Stomp\Protocol;
 use Stomp\Protocol\ActiveMq;
 use PHPUnit_Framework_TestCase;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**

--- a/tests/Unit/Stomp/Protocol/ActiveMqTest.php
+++ b/tests/Unit/Stomp/Protocol/ActiveMqTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace FuseSource\Tests\Unit\Protocol;
+namespace Stomp\Tests\Unit\Protocol;
 
-use FuseSource\Stomp\Protocol;
-use FuseSource\Stomp\Protocol\ActiveMq;
+use Stomp\Protocol;
+use Stomp\Protocol\ActiveMq;
 use PHPUnit_Framework_TestCase;
 /**
  *

--- a/tests/Unit/Stomp/StompTest.php
+++ b/tests/Unit/Stomp/StompTest.php
@@ -223,7 +223,7 @@ class StompTest extends PHPUnit_Framework_TestCase
     public function testLoginDataFromConstructorIsUsedIfNoLoginDataPassedToConnect()
     {
         $stomp = $this->getStompMockWithSendFrameCatcher($lastSendFrame, $lastSyncState);
-        $connection = $this->getMock('Stomp\Connection', [], [], '', false);
+        $connection = $this->getMock('Stomp\Connection', array(), array(), '', false);
 
         $stomp->__construct($connection, 'myUser', 'myPassword');
 
@@ -247,7 +247,7 @@ class StompTest extends PHPUnit_Framework_TestCase
     public function testLoginDataFromConstructorIsIgnoredIfLoginDataPassedToConnect()
     {
         $stomp = $this->getStompMockWithSendFrameCatcher($lastSendFrame, $lastSyncState);
-        $connection = $this->getMock('Stomp\Connection', [], [], '', false);
+        $connection = $this->getMock('Stomp\Connection', array(), array(), '', false);
 
         $stomp->__construct($connection, 'myUserFirst', 'myPasswordFirst');
 

--- a/tests/Unit/Stomp/StompTest.php
+++ b/tests/Unit/Stomp/StompTest.php
@@ -1,4 +1,12 @@
 <?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Stomp\Tests\Unit\Stomp;
 
 use Stomp\Connection;
@@ -7,22 +15,7 @@ use Stomp\Frame;
 use Stomp\Stomp;
 use PHPUnit_Framework_TestCase;
 use ReflectionMethod;
-/**
- *
- * Copyright 2005-2006 The Apache Software Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 /* vim: set expandtab tabstop=3 shiftwidth=3: */
 
 /**

--- a/tests/Unit/Stomp/StompTest.php
+++ b/tests/Unit/Stomp/StompTest.php
@@ -1,10 +1,10 @@
 <?php
-namespace FuseSource\Tests\Unit\Stomp;
+namespace Stomp\Tests\Unit\Stomp;
 
-use FuseSource\Stomp\Connection;
-use FuseSource\Stomp\Exception\UnexpectedResponseException;
-use FuseSource\Stomp\Frame;
-use FuseSource\Stomp\Stomp;
+use Stomp\Connection;
+use Stomp\Exception\UnexpectedResponseException;
+use Stomp\Frame;
+use Stomp\Stomp;
 use PHPUnit_Framework_TestCase;
 use ReflectionMethod;
 /**
@@ -47,7 +47,7 @@ class StompTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \FuseSource\Stomp\Exception\ConnectionException
+     * @expectedException \Stomp\Exception\ConnectionException
      */
     public function testConnectWillThrowExceptionIfNoFrameWasRead()
     {
@@ -66,7 +66,7 @@ class StompTest extends PHPUnit_Framework_TestCase
 
         $stomp->connect();
 
-        $this->assertInstanceOf('\FuseSource\Stomp\Protocol\RabbitMq', $stomp->getProtocol(), 'Unexpected Protocol.');
+        $this->assertInstanceOf('\Stomp\Protocol\RabbitMq', $stomp->getProtocol(), 'Unexpected Protocol.');
     }
 
 
@@ -80,13 +80,13 @@ class StompTest extends PHPUnit_Framework_TestCase
 
         $stomp->connect();
 
-        $this->assertInstanceOf('\FuseSource\Stomp\Protocol\ActiveMq', $stomp->getProtocol(), 'Unexpected Protocol.');
+        $this->assertInstanceOf('\Stomp\Protocol\ActiveMq', $stomp->getProtocol(), 'Unexpected Protocol.');
         $this->assertEquals('your-session-id', $stomp->getSessionId(), 'Wrong session id.');
     }
 
 
     /**
-     * @expectedException FuseSource\Stomp\Exception\StompException
+     * @expectedException Stomp\Exception\StompException
      */
     public function testWaitForReceiptWillThrowExceptionOnIdMissmatch()
     {
@@ -123,7 +123,7 @@ class StompTest extends PHPUnit_Framework_TestCase
 
 
     /**
-     * @expectedException FuseSource\Stomp\Exception\MissingReceiptException
+     * @expectedException Stomp\Exception\MissingReceiptException
      * @expectedExceptionMessage my-expected-receive-id
      */
     public function testWaitForReceiptWillThrowExceptionIfConnectionReadTimeoutOccurs()
@@ -146,7 +146,7 @@ class StompTest extends PHPUnit_Framework_TestCase
      */
     protected function getStompWithInjectedMockedConnectionReadResult($readFrameResult)
     {
-        $connection = $this->getMockBuilder('\FuseSource\Stomp\Connection')
+        $connection = $this->getMockBuilder('\Stomp\Connection')
             ->setMethods(array('readFrame', 'writeFrame'))
             ->disableOriginalConstructor()
             ->getMock();
@@ -176,7 +176,7 @@ class StompTest extends PHPUnit_Framework_TestCase
         $stomp->send('correct-destination', $frame, $headers, true);
 
         // verify
-        $this->assertInstanceOf('\FuseSource\Stomp\Frame', $lastSendFrame);
+        $this->assertInstanceOf('\Stomp\Frame', $lastSendFrame);
         $this->assertEquals($frame->command, $lastSendFrame->command, 'Send must not change frame command.');
         $this->assertEquals(
             'correct-destination',
@@ -206,7 +206,7 @@ class StompTest extends PHPUnit_Framework_TestCase
         $stomp->send('correct-destination', $framebody, $headers, false);
 
         // verify
-        $this->assertInstanceOf('\FuseSource\Stomp\Frame', $lastSendFrame);
+        $this->assertInstanceOf('\Stomp\Frame', $lastSendFrame);
         $this->assertEquals('SEND', $lastSendFrame->command, 'Send must set SEND as frame command, if frame was text.');
         $this->assertEquals(
             'correct-destination',
@@ -235,7 +235,7 @@ class StompTest extends PHPUnit_Framework_TestCase
      */
     protected function getStompMockWithSendFrameCatcher(&$lastSendFrame, &$lastSyncState)
     {
-        $stomp = $this->getMockBuilder('\FuseSource\Stomp\Stomp')
+        $stomp = $this->getMockBuilder('\Stomp\Stomp')
             ->setMethods(array('sendFrame'))
             ->disableOriginalConstructor()
             ->getMock();
@@ -258,7 +258,7 @@ class StompTest extends PHPUnit_Framework_TestCase
 
     public function testSendFrameWithSyncWillLeadToMessageWithReceiptHeader()
     {
-        $connection = $this->getMockBuilder('\FuseSource\Stomp\Connection')
+        $connection = $this->getMockBuilder('\Stomp\Connection')
             ->setMethods(array('writeFrame', 'readFrame'))
             ->disableOriginalConstructor()
             ->getMock();
@@ -287,11 +287,11 @@ class StompTest extends PHPUnit_Framework_TestCase
         try {
             $stomp->setReceiptWait(0);
             $stomp->sendFrame(new Frame(), true);
-        } catch (\FuseSource\Stomp\Exception\MissingReceiptException $ex) {
+        } catch (\Stomp\Exception\MissingReceiptException $ex) {
             // is allowed, since we send no receipt...
         }
 
-        $this->assertInstanceOf('\FuseSource\Stomp\Frame', $lastWriteFrame);
+        $this->assertInstanceOf('\Stomp\Frame', $lastWriteFrame);
         $this->assertArrayHasKey('receipt', $lastWriteFrame->headers, 'Written frame should have a "receipt" header.');
 
     }
@@ -299,7 +299,7 @@ class StompTest extends PHPUnit_Framework_TestCase
 
     public function testWaitForReceiptWillQueueUpFramesWithNoReceiptCommand()
     {
-        $connection = $this->getMockBuilder('\FuseSource\Stomp\Connection')
+        $connection = $this->getMockBuilder('\Stomp\Connection')
             ->setMethods(array('readFrame'))
             ->disableOriginalConstructor()
             ->getMock();
@@ -351,7 +351,7 @@ class StompTest extends PHPUnit_Framework_TestCase
 
     public function testAckWillUseMessageAsMessageIdForAckFrame()
     {
-        $connection = $this->getMockBuilder('\FuseSource\Stomp\Connection')
+        $connection = $this->getMockBuilder('\Stomp\Connection')
             ->setMethods(array('readFrame', 'writeFrame'))
             ->disableOriginalConstructor()
             ->getMock();
@@ -363,7 +363,7 @@ class StompTest extends PHPUnit_Framework_TestCase
                     new Frame('CONNECTED', array('session' => 'id', 'server' => 'activemq'))
                 )
             );
-        $stomp = $this->getMockBuilder('\FuseSource\Stomp\Stomp')
+        $stomp = $this->getMockBuilder('\Stomp\Stomp')
             ->setMethods(array('sendFrame'))
             ->setConstructorArgs(array($connection))
             ->getMock();

--- a/travisci/bin/ci/install_dependencies.sh
+++ b/travisci/bin/ci/install_dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-AMQ_VERSION="5.10.0"
+AMQ_VERSION="5.10.2"
 wget http://mirror.netcologne.de/apache.org/activemq/${AMQ_VERSION}/apache-activemq-${AMQ_VERSION}-bin.tar.gz
 tar -xzf apache-activemq-${AMQ_VERSION}-bin.tar.gz
 

--- a/travisci/bin/ci/stop_activemq.sh
+++ b/travisci/bin/ci/stop_activemq.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./apache-activemq-5.10.0/bin/activemq stop
+./apache-activemq-5.10.2/bin/activemq stop


### PR DESCRIPTION
This could be the first release from our new stomp-php repository.

I tried to collect most changes seen on the original repository network graph. These changes have been applied against a already modified code base, which means that there is no direct backwards compatibility.

- This versions aims to be pretty close to the previous https://github.com/dejanb/stomp-php/releases/tag/2.1.1
- It should be the last php-5.3 compatible version.
- It uses a new namespace (Stomp)
