### PR TITLE
fixed null byte error on rabbitmq stomp plugin

### DIFF
--- a/src/Stomp/Connection.php
+++ b/src/Stomp/Connection.php
@@ -314,7 +314,7 @@ class Connection
         }
 
         do {
-            $read = @fgets($this->connection, 1024);
+            $read = @fread($this->connection, 1024);
             if ($read === false || $read === '') {
                 throw new ConnectionException('Was not possible to read data from stream.', $this->activeHost);
             }


### PR DESCRIPTION
This is pull request for my issue
https://github.com/stomp-php/stomp-php/issues/21

Problem with rabbitMQ connection frame.
https://www.rabbitmq.com/stomp.html
Last string on CONNECTED or RECEIPT has "\n\x00"

Problem on src/Stomp/Connection.php line 317 with "fgets" php function. "fgets" reads the string to the symbol "\n" and never reach "\x00".
Change it to "fread" and problem gone.

You can read details here
http://lists.rabbitmq.com/pipermail/rabbitmq-discuss/2008-September/001523.html