### PR TITLE
replace fread with stream_get_line and skip empty lines (heart-beats)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,9 @@ Changelog stomp-php
 
 3.0.1
 -----
-- changed back to `fread`, FrameParser should handle more than one Frame (https://github.com/stomp-php/stomp-php/issues/21) 
-
-WIP
----
+- changed back to `fread`, FrameParser should handle more than one Frame (https://github.com/stomp-php/stomp-php/issues/21)
+ 
+3.0.2
+-----
+- changed to `stream_read_line` (https://github.com/stomp-php/stomp-php/issues/23, https://gist.github.com/arjenm/4ae508767b1af73c63f5)
 - Updated function testsuite for different brokers (amq,aplo,rabbit), update travis-ci.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ adds some ActiveMQ specific features that could make your messaging from PHP eas
 
 ## Version choice
 
-- For new projects you should use version `3.0.0` which is the last `php-5.3` compatible.
+- For new projects you should use version `3.*` which is the last `php-5.3` compatible.
 - For running projects with `fusesource/stomp-php@2.x` clients you can use version `2.2.2`.
 - All version newer that `2.x` won't be compatible with `fusesource/stomp-php`. (https://github.com/dejanb/stomp-php.)  
 
@@ -23,7 +23,7 @@ Just add
 
 ```json
     "require": {
-        "stomp-php/stomp-php": "3.0.0"
+        "stomp-php/stomp-php": "3.*"
     }
 ```
 

--- a/tests/Functional/ActiveMq/ClientTest.php
+++ b/tests/Functional/ActiveMq/ClientTest.php
@@ -41,6 +41,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         parent::setUp();
 
         $this->Stomp = new Stomp($this->broker);
+        $this->Stomp->getConnection()->setReadTimeout(0, 400000);
     }
     /**
      * Cleans up the environment after running a test.
@@ -76,8 +77,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $this->Stomp->connect();
         }
 
-        $this->Stomp->getConnection()->setReadTimeout(5);
-
         $this->assertFalse($this->Stomp->getConnection()->hasDataToRead(), 'Has frame to read when non expected');
 
         $this->Stomp->send($this->queue, 'testHasFrameToRead');
@@ -93,8 +92,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->Stomp->ack($frame);
 
         $this->Stomp->disconnect();
-
-        $this->Stomp->getConnection()->setReadTimeout(60);
     }
 
     /**
@@ -163,7 +160,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testAbort()
     {
-        $this->Stomp->getConnection()->setReadTimeout(1);
         if (! $this->Stomp->isConnected()) {
             $this->Stomp->connect();
         }
@@ -356,7 +352,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $consumer2 = new Stomp($this->broker);
         $consumer2->sync = false;
         $consumer2->clientId = 'test';
-        $consumer2->getConnection()->setReadTimeout(1);
+        $consumer2->getConnection()->setReadTimeout(0, 500000);
         $consumer2->connect('system', 'manager');
         $consumer2->subscribe($this->topic, null, null, true);
 

--- a/tests/Functional/ActiveMq/SyncTest.php
+++ b/tests/Functional/ActiveMq/SyncTest.php
@@ -53,7 +53,7 @@ class SyncTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->Stomp->send('/queue/test', 'test 1'));
         $this->assertTrue($this->Stomp->send('/queue/test', 'test 2'));
 
-        $this->Stomp->getConnection()->setReadTimeout(5);
+        $this->Stomp->getConnection()->setReadTimeout(0, 500000);
 
         $frame = $this->Stomp->readFrame();
         $this->assertEquals('test 1', $frame->body, 'test 1 not received!');
@@ -88,7 +88,7 @@ class SyncTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($this->Stomp->subscribe('/queue/test'));
 
-        $this->Stomp->getConnection()->setReadTimeout(1, 0);
+        $this->Stomp->getConnection()->setReadTimeout(0, 500000);
 
         $frame = $this->Stomp->readFrame();
         $this->assertFalse($frame);

--- a/tests/Functional/Generic/ConnectionTest.php
+++ b/tests/Functional/Generic/ConnectionTest.php
@@ -42,7 +42,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             $connection->readFrame();
             $this->fail('Expected a exception!');
         } catch (ConnectionException $excpetion) {
-            $this->assertContains('Was not possible to read data from stream.', $excpetion->getMessage());
+            $this->assertContains('Check failed to determine if the socket is readable.', $excpetion->getMessage());
         }
     }
 

--- a/tests/Functional/RabbitMq/ClientTest.php
+++ b/tests/Functional/RabbitMq/ClientTest.php
@@ -65,7 +65,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $this->Stomp->connect($this->login, $this->password);
         }
 
-        $this->Stomp->getConnection()->setReadTimeout(5);
+        $this->Stomp->getConnection()->setReadTimeout(0, 500000);
 
         $this->assertFalse($this->Stomp->getConnection()->hasDataToRead(), 'Has frame to read when non expected');
 
@@ -82,8 +82,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->Stomp->ack($frame);
 
         $this->Stomp->disconnect();
-
-        $this->Stomp->getConnection()->setReadTimeout(60);
     }
 
     /**
@@ -151,7 +149,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testAbort()
     {
-        $this->Stomp->getConnection()->setReadTimeout(1);
+        $this->Stomp->getConnection()->setReadTimeout(0, 500000);
         if (! $this->Stomp->isConnected()) {
             $this->Stomp->connect($this->login, $this->password);
         }
@@ -346,7 +344,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $consumer2 = new Stomp($this->broker);
         $consumer2->sync = true;
         $consumer2->clientId = 'test';
-        $consumer2->getConnection()->setReadTimeout(1);
+        $consumer2->getConnection()->setReadTimeout(0, 500000);
         $consumer2->connect($this->login, $this->password);
         $consumer2->subscribe($this->topic, array('persistent' => 'true'));
 

--- a/travisci/bin/ci/setup_activemq.sh
+++ b/travisci/bin/ci/setup_activemq.sh
@@ -7,7 +7,7 @@ EXTRACT_PATH=$3
 cd "$EXTRACT_PATH"
 
 if [ ! -e "$EXTRACT_PATH/apache-activemq-${AMQ_VERSION}-bin.tar.gz" ]; then
-    wget "http://mirror.netcologne.de/apache.org/activemq/${AMQ_VERSION}/apache-activemq-${AMQ_VERSION}-bin.tar.gz"
+    wget "http://archive.apache.org/dist/activemq/${AMQ_VERSION}/apache-activemq-${AMQ_VERSION}-bin.tar.gz"
 fi
 
 if [ ! -d "$EXTRACT_PATH/apache-activemq-${AMQ_VERSION}" ]; then


### PR DESCRIPTION
Fixes issue #23.
- replaces `fread` with `stream_get_line`
- skips empty lines in front and after frames (heartbeats)

Special thanks to @arjenm.