### PR TITLE
determine frame size by looking for content-length header (issue #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,5 +50,6 @@ Changelog stomp-php
  
 3.0.2
 -----
-- changed to `stream_read_line` (https://github.com/stomp-php/stomp-php/issues/23, https://gist.github.com/arjenm/4ae508767b1af73c63f5)
+- changed to `stream_read_line` (https://github.com/stomp-php/stomp-php/issues/24, https://gist.github.com/arjenm/4ae508767b1af73c63f5)
+- add support for `content-length` header (https://github.com/stomp-php/stomp-php/issues/23, https://gist.github.com/arjenm/7bab3a10f6d2460c7891)
 - Updated function testsuite for different brokers (amq,aplo,rabbit), update travis-ci.

--- a/tests/Unit/Stomp/ParserTest.php
+++ b/tests/Unit/Stomp/ParserTest.php
@@ -50,4 +50,19 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('var', $result->body);
         $this->assertEquals('value1', $result->headers['header1']);
     }
+
+    public function testParseFrameTransformsToFrameZeroByteContent()
+    {
+        $body = "var\x00var\x002";
+        $msg = "CMD\nheader1:value1\ncontent-length:" . strlen($body) . "\n\n" . $body . "\x00";
+
+        $parser = new Parser();
+        $parser->addData($msg);
+        $parser->parse();
+        $result = $parser->getFrame();
+
+        $this->assertInstanceOf('\Stomp\Frame', $result);
+        $this->assertEquals($body, $result->body);
+        $this->assertEquals('value1', $result->headers['header1']);
+    }
 }

--- a/travisci/bin/ci/setup_apollomq.sh
+++ b/travisci/bin/ci/setup_apollomq.sh
@@ -7,7 +7,7 @@ EXTRACT_PATH=$3
 cd "$EXTRACT_PATH"
 
 if [ ! -e "$EXTRACT_PATH/apache-apollo-${APLO_VERSION}-unix-distro.tar.gz" ]; then
-    wget "http://mirror.netcologne.de/apache.org/activemq/activemq-apollo/${APLO_VERSION}/apache-apollo-${APLO_VERSION}-unix-distro.tar.gz"
+    wget "http://archive.apache.org/dist/activemq/activemq-apollo/${APLO_VERSION}/apache-apollo-${APLO_VERSION}-unix-distro.tar.gz"
 
 fi
 


### PR DESCRIPTION
This will fix #23 by using `preg_match` to determine if there is a `content-length` header. (gist from @arjenm)

- It could fail if the actual message body contains a similar structure too.
- But from my point of view it's okay for version 3, as version 4 brings us the complete support for `stomp-1.1+`