### PR TITLE
add headers to connect call to allow specifing a 'host'

### DIFF
--- a/src/Stomp/Protocol.php
+++ b/src/Stomp/Protocol.php
@@ -54,15 +54,18 @@ class Protocol
      *
      * @param string $login
      * @param string $passcode
+     * @param string[] $headers
      * @return Frame
      */
-    final public function getConnectFrame($login = '', $passcode = '')
+    final public function getConnectFrame($login = '', $passcode = '', $headers = [])
     {
         $frame = new Frame('CONNECT');
 
         if ($login || $passcode) {
             $frame->addHeaders(compact('login', 'passcode'));
         }
+
+        $frame->addHeaders($headers);
 
         if ($this->hasClientId()) {
             $frame->setHeader('client-id', $this->getClientId());

--- a/src/Stomp/Stomp.php
+++ b/src/Stomp/Stomp.php
@@ -130,10 +130,11 @@ class Stomp
      *
      * @param string $login
      * @param string $passcode
+     * @param string[] $headers
      * @return boolean
      * @throws StompException
      */
-    public function connect($login = null, $passcode = null)
+    public function connect($login = null, $passcode = null, $headers = [])
     {
         if ($login !== null) {
             $this->login = $login;
@@ -143,7 +144,7 @@ class Stomp
         }
         $this->connection->connect();
         $this->protocol = new Protocol($this->prefetchSize, $this->clientId);
-        $this->sendFrame($this->protocol->getConnectFrame($this->login, $this->passcode), false);
+        $this->sendFrame($this->protocol->getConnectFrame($this->login, $this->passcode, $headers), false);
         if ($frame = $this->connection->readFrame()) {
             if ($frame->command != 'CONNECTED') {
                 throw new UnexpectedResponseException($frame, 'Expected a CONNECTED Frame!');


### PR DESCRIPTION
in order to allow conformance to http://stomp.github.io/stomp-specification-1.1.html, it is required to specify a 'host' header in the CONNECT call. This is necessary f.i. to use vhosts in RabbitMQ.

I kept the implementation generic enough to allow also potential future headers to CONNECT.

Should the pull request not conform to your expectations, i'd be glad to do corrections in order to get it merged.

Thanks