### PR TITLE
in legacyMode (stomp 1.0) we still need to escape the LF char

### DIFF
--- a/src/Stomp/Transport/Frame.php
+++ b/src/Stomp/Transport/Frame.php
@@ -195,7 +195,7 @@ class Frame implements ArrayAccess
     protected function encodeHeaderValue($value)
     {
         if ($this->legacyMode) {
-            return $value;
+            return str_replace(["\n"], ['\n'], $value);
         }
         return str_replace(["\\", "\r", "\n", ':'], ["\\\\", '\r', '\n', '\c'], $value);
     }

--- a/tests/Unit/Stomp/Transport/FrameTest.php
+++ b/tests/Unit/Stomp/Transport/FrameTest.php
@@ -121,7 +121,7 @@ hello queue a^@' . "\x00",
         $frame->legacyMode(true);
 
         $result = $frame->__toString();
-        $expected = "SEND\nmy:var:\\multi\nline\r!\n\n\x00";
+        $expected = "SEND\nmy:var:\\multi\\nline\r!\n\n\x00";
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
to be 100% correct we should escape the `LF` + `:` in header names and only `LF` in header values.

I tried to keep the patch as small as possible, therefore didnt split up escaping in header-name and header-value.

refs https://github.com/stomp-php/stomp-php/issues/35