### PR TITLE
add parameter to constructor

### DIFF
--- a/src/FuseSource/Stomp/Stomp.php
+++ b/src/FuseSource/Stomp/Stomp.php
@@ -110,12 +110,15 @@ class Stomp
      * Constructor
      *
      * @param string|Connection $broker Broker URL or a connection
+     * @param string|null $clientId
      * @throws StompException
      * @see Connection::__construct()
      */
-    public function __construct ($broker)
+    public function __construct ($broker, $clientId = null)
     {
         $this->_connection = $broker instanceof Connection ? $broker : new Connection($broker);
+        
+        $this->clientId    = $clientId;
     }
 
     /**


### PR DESCRIPTION
Add an optional parameter to constructor to set $clientId in order to inject stomp as a service in Symfony, because it's not possible to set public fields in Symfony Dependency Injection.