### PR TITLE
fixed header escaping in legacy mode in Parser

### DIFF
--- a/src/Stomp/Transport/Parser.php
+++ b/src/Stomp/Transport/Parser.php
@@ -287,7 +287,7 @@ class Parser
     private function decodeHeaderValue($value)
     {
         if ($this->legacyMode) {
-            return $value;
+            return str_replace(["\n"], ['\n'], $value);
         }
         return str_replace(['\r', '\n', '\c', "\\\\"], ["\r", "\n", ':', "\\"], $value);
     }

--- a/src/Stomp/Transport/Parser.php
+++ b/src/Stomp/Transport/Parser.php
@@ -238,7 +238,8 @@ class Parser
     private function setFrame($bodySize)
     {
         $frame = new Frame($this->command, $this->headers, (string) substr($this->buffer, $this->offset, $bodySize));
-
+        $frame->legacyMode($this->legacyMode);
+ 
         if ($frame['transformation'] == 'jms-map-json') {
             $this->frame = new Map($frame);
         } else {
@@ -287,7 +288,7 @@ class Parser
     private function decodeHeaderValue($value)
     {
         if ($this->legacyMode) {
-            return str_replace(["\n"], ['\n'], $value);
+            return str_replace(['\n'], ["\n"], $value);
         }
         return str_replace(['\r', '\n', '\c', "\\\\"], ["\r", "\n", ':', "\\"], $value);
     }

--- a/tests/Unit/Stomp/Transport/ParserTest.php
+++ b/tests/Unit/Stomp/Transport/ParserTest.php
@@ -116,7 +116,8 @@ class ParserTest extends PHPUnit_Framework_TestCase
         $this->parser->legacyMode(true);
         $this->parser->addData($frame);
         $this->parser->parse();
-        $expected = new Frame('COMMAND', ['X-Proof' => "Hello\\c\\r\\n  \\\\World!"], "Body");
+        $expected = new Frame('COMMAND', ['X-Proof' => "Hello\\c\\r\n  \\\\World!"], "Body");
+        $expected->legacyMode(true);
         $actual = $this->parser->getFrame();
 
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
this effectively applies the same patch as https://github.com/stomp-php/stomp-php/commit/6a7ab1a923589f7339447c9f57634b3c2cea29d4 also in the Parser class.

see https://github.com/stomp-php/stomp-php/pull/37 for background.