### PR TITLE
Validate given ack SUBSCRIBE frame values against the STOMP spec

### DIFF
--- a/src/Stomp/Protocol/Protocol.php
+++ b/src/Stomp/Protocol/Protocol.php
@@ -100,6 +100,19 @@ class Protocol
      */
     public function getSubscribeFrame($destination, $subscriptionId = null, $ack = 'auto', $selector = null)
     {
+        // validate ACK types per spec
+        // https://stomp.github.io/stomp-specification-1.0.html#frame-ACK
+        // https://stomp.github.io/stomp-specification-1.1.html#ACK
+        // https://stomp.github.io/stomp-specification-1.2.html#ACK
+        if ($this->hasVersion(Version::VERSION_1_1)) {
+            $validAcks = array('auto', 'client', 'client-individual');
+        } else {
+            $validAcks = array('auto', 'client');
+        }
+        if (!in_array($ack, $validAcks)) {
+            throw new StompException('"'. $ack .'" is not a valid ack value for STOMP '. $this->version .'. A valid value is one of '. implode(',', $validAcks));
+        }
+        
         $frame = $this->createFrame('SUBSCRIBE');
 
         $frame['destination'] = $destination;

--- a/tests/Unit/Stomp/Protocol/ProtocolTestCase.php
+++ b/tests/Unit/Stomp/Protocol/ProtocolTestCase.php
@@ -13,6 +13,7 @@ use PHPUnit_Framework_TestCase;
 use Stomp\Protocol\Protocol;
 use Stomp\Protocol\Version;
 use Stomp\Transport\Frame;
+use Stomp\Exception\StompException;
 
 /**
  * Protocol test cases.
@@ -44,12 +45,24 @@ abstract class ProtocolTestCase extends PHPUnit_Framework_TestCase
     {
         $protocol = $this->getProtocol();
 
-        $actual = $protocol->getSubscribeFrame('my-destination', 'my-sub-id', 'my-ack', 'my-selector');
+        $actual = $protocol->getSubscribeFrame('my-destination', 'my-sub-id', 'client', 'my-selector');
         $this->assertIsSubscribeFrame($actual);
         $this->assertEquals('my-destination', $actual['destination']);
-        $this->assertEquals('my-ack', $actual['ack']);
+        $this->assertEquals('client', $actual['ack']);
         $this->assertEquals('my-sub-id', $actual['id']);
         $this->assertEquals('my-selector', $actual['selector']);
+    }
+
+    public function testInvalidSubscribeFrameAck()
+    {
+        $protocol = $this->getProtocol();
+
+        try {
+            $actual = $protocol->getSubscribeFrame('my-destination', 'my-sub-id', 'my-ack', 'my-selector');
+            $this->fail();
+        } catch (StompException $e) {
+            $this->assertContains('"my-ack" is not a valid ack value', $e->getMessage());
+        }
     }
 
     public function testAckVersionZero()


### PR DESCRIPTION
As I recently stumbled over problems because I used 'client-individual' in a STOMP1.0 environment.