### PR TITLE
Added a OpenMq Broker

### DIFF
--- a/src/Stomp/Broker/OpenMq/OpenMq.php
+++ b/src/Stomp/Broker/OpenMq/OpenMq.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Broker\OpenMq;
+
+use Stomp\Protocol\Protocol;
+use Stomp\Transport\Frame;
+use Stomp\Protocol\Version;
+
+/**
+ * OpenMq Stomp dialect.
+ *
+ * @package Stomp
+ * @author Markus Staab <maggus.staab@googlemail.com>
+ */
+class OpenMq extends Protocol
+{
+    /**
+     * @inheritdoc
+     */
+    public function getAckFrame(Frame $frame, $transactionId = null)
+    {
+        $ack = $this->createFrame('ACK');
+        $ack['transaction'] = $transactionId;
+        if ($this->hasVersion(Version::VERSION_1_2)) {
+            $ack['id'] = $frame->getMessageId();
+        } else {
+            $ack['message-id'] = $frame->getMessageId();
+        }
+        // spec quote: "ACK should always specify a "subscription" header for the subscription id that the message to be acked was delivered to ."
+        // see https://mq.java.net/4.4-content/stomp-funcspec.html
+        if (isset($frame['subscription'])) {
+            $ack['subscription'] = $frame['subscription'];
+        }
+        return $ack;
+    }
+}

--- a/src/Stomp/Protocol/Version.php
+++ b/src/Stomp/Protocol/Version.php
@@ -11,6 +11,7 @@ namespace Stomp\Protocol;
 use Stomp\Broker\ActiveMq\ActiveMq;
 use Stomp\Broker\Apollo\Apollo;
 use Stomp\Broker\RabbitMq\RabbitMq;
+use Stomp\Broker\OpenMq\OpenMq;
 use Stomp\Exception\StompException;
 use Stomp\Exception\UnexpectedResponseException;
 use Stomp\Transport\Frame;
@@ -76,6 +77,8 @@ class Version
             return new Apollo($clientId, $version, $server);
         } elseif (stristr($server, 'activemq') !== false) {
             return new ActiveMq($clientId, $version, $server);
+        } elseif (stristr($server, 'open message queue') !== false) {
+            return new OpenMq($clientId, $version, $server);
         }
         return new Protocol($clientId, $version, $server);
     }

--- a/tests/Unit/Stomp/Broker/OpenMq/OpenMqTest.php
+++ b/tests/Unit/Stomp/Broker/OpenMq/OpenMqTest.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Tests\Unit\Stomp\Broker\OpenMq;
+
+use Stomp\Broker\OpenMq\OpenMq;
+use Stomp\Protocol\Version;
+use Stomp\Tests\Unit\Stomp\Protocol\ProtocolTestCase;
+use Stomp\Transport\Frame;
+
+/**
+ * OpenMqTest
+ *
+ * @package Stomp\Tests\Unit\Stomp\Broker\OpenMq
+ * @author Markus Staab <maggus.staab@googlemail.com>
+ */
+class OpenMqTest extends ProtocolTestCase
+{
+    public function testAckSubscription()
+    {
+        $instance = $this->getProtocol(Version::VERSION_1_0);
+
+        $resultAckBased = $instance->getAckFrame(new Frame(null, ['subscription' => '1234']), 'my-transaction');
+        $this->assertEquals('1234', $resultAckBased['subscription']);
+        $this->assertIsAckFrame($resultAckBased);
+    }
+
+    protected function getProtocolClassFqn()
+    {
+        return OpenMq::class;
+    }
+}


### PR DESCRIPTION
handle proprietary subscription header in ACKs.

spec quote: `ACK should always specify a "subscription" header for the subscription id that the message to be acked was delivered to .`
see https://mq.java.net/4.4-content/stomp-funcspec.html

this fixes a `Error "ACK: [BSS4008]: Can not determine subscriber to ACK message ID:22498-127.0.1.1(c4:69:92:9a:cb:84)-1-1464190125477. Please specify subscription header"` error when ACK a message originating from a subscription.

OpenMQ is shipped with the glassfish application server.