### PR TITLE
Ensure if a content length is specified, we wait for the full body.

### DIFF
--- a/src/Stomp/Transport/Parser.php
+++ b/src/Stomp/Transport/Parser.php
@@ -216,9 +216,12 @@ class Parser
     private function detectFrameEnd()
     {
         $bodySize = null;
-        if ($this->expectedBodyLength && ($this->bufferSize - $this->offset) >= $this->expectedBodyLength) {
-            $bodySize = $this->expectedBodyLength;
-        } elseif (($frameEnd = strpos($this->buffer, self::FRAME_END, $this->offset)) !== false) {
+        if ($this->expectedBodyLength) {
+            if (($this->bufferSize - $this->offset) >= $this->expectedBodyLength) {
+                $bodySize = $this->expectedBodyLength;
+            }
+        }
+        elseif (($frameEnd = strpos($this->buffer, self::FRAME_END, $this->offset)) !== false) {
             $bodySize = $frameEnd - $this->offset;
         }
 


### PR DESCRIPTION
Fixes #53.