### PR TITLE
Stomp 1.1 ACK/NACK fix

### DIFF
--- a/src/Stomp/Broker/ActiveMq/ActiveMq.php
+++ b/src/Stomp/Broker/ActiveMq/ActiveMq.php
@@ -81,11 +81,22 @@ class ActiveMq extends Protocol
     {
         $ack = $this->createFrame('ACK');
         $ack['transaction'] = $transactionId;
-        if ($this->hasVersion(Version::VERSION_1_2)) {
-            $ack['id'] = $frame['ack'] ?: $frame->getMessageId();
-        } else {
-            $ack['message-id'] = $frame['ack'] ?: $frame->getMessageId();
+
+        switch ($this->getVersion()) {
+            case Version::VERSION_1_0:
+                $ack['message-id'] = $frame['ack'] ?: $frame->getMessageId();
+                break;
+            case Version::VERSION_1_1:
+                $ack['message-id'] = $frame['ack'] ?: $frame->getMessageId();
+                if (false === is_null($frame->offsetGet('subscription'))) {
+                    $ack['subscription'] = $frame->offsetGet('subscription');
+                }
+                break;
+            case Version::VERSION_1_2:
+                $ack['id'] = $frame['ack'] ?: $frame->getMessageId();
+                break;
         }
+
         return $ack;
     }
 
@@ -96,11 +107,22 @@ class ActiveMq extends Protocol
     {
         $nack = $this->createFrame('NACK');
         $nack['transaction'] = $transactionId;
-        if ($this->hasVersion(Version::VERSION_1_2)) {
-            $nack['id'] = $frame['ack'] ?: $frame->getMessageId();
-        } else {
-            $nack['message-id'] = $frame['ack'] ?: $frame->getMessageId();
+
+        switch ($this->getVersion()) {
+            case Version::VERSION_1_0:
+                $nack['message-id'] = $frame['ack'] ?: $frame->getMessageId();
+                break;
+            case Version::VERSION_1_1:
+                $nack['message-id'] = $frame['ack'] ?: $frame->getMessageId();
+                if (false === is_null($frame->offsetGet('subscription'))) {
+                    $nack['subscription'] = $frame->offsetGet('subscription');
+                }
+                break;
+            case Version::VERSION_1_2:
+                $nack['id'] = $frame['ack'] ?: $frame->getMessageId();
+                break;
         }
+
         return $nack;
     }
 

--- a/tests/Unit/Stomp/Broker/ActiveMq/ActiveMqTest.php
+++ b/tests/Unit/Stomp/Broker/ActiveMq/ActiveMqTest.php
@@ -88,6 +88,26 @@ class ActiveMqTestCase extends ProtocolTestCase
 
     }
 
+    public function testAckVersionOne()
+    {
+        $instance = $this->getProtocol(Version::VERSION_1_1);
+
+        $resultAckBased = $instance->getAckFrame(new Frame(null, ['ack' => 'ack-value']), 'my-transaction');
+        $this->assertIsAckFrame($resultAckBased);
+        $this->assertEquals('ack-value', $resultAckBased['message-id']);
+        $this->assertEquals('my-transaction', $resultAckBased['transaction']);
+
+        $resultIdBased = $instance->getAckFrame(new Frame(null, [
+            'message-id' => 'id-value',
+            'subscription' => 'my-subscription'
+        ]), 'my-transaction');
+
+        $this->assertIsAckFrame($resultIdBased);
+        $this->assertEquals('id-value', $resultIdBased['message-id']);
+        $this->assertEquals('my-subscription', $resultIdBased['subscription']);
+        $this->assertEquals('my-transaction', $resultAckBased['transaction']);
+    }
+
     public function testAckVersionTwo()
     {
         $instance = $this->getProtocol(Version::VERSION_1_2);
@@ -117,6 +137,27 @@ class ActiveMqTestCase extends ProtocolTestCase
         $this->assertEquals('my-transaction', $resultIdBased['transaction']);
         $this->assertIsNackFrame($resultIdBased);
 
+    }
+
+
+    public function testNackVersionOne()
+    {
+        $instance = $this->getProtocol(Version::VERSION_1_1);
+
+        $resultAckBased = $instance->getNackFrame(new Frame(null, ['ack' => 'ack-value']), 'my-transaction');
+        $this->assertIsNackFrame($resultAckBased);
+        $this->assertEquals('ack-value', $resultAckBased['message-id']);
+        $this->assertEquals('my-transaction', $resultAckBased['transaction']);
+
+        $resultIdBased = $instance->getNackFrame(new Frame(null, [
+            'message-id' => 'id-value',
+            'subscription' => 'my-subscription'
+        ]), 'my-transaction');
+
+        $this->assertIsNackFrame($resultIdBased);
+        $this->assertEquals('id-value', $resultIdBased['message-id']);
+        $this->assertEquals('my-subscription', $resultIdBased['subscription']);
+        $this->assertEquals('my-transaction', $resultAckBased['transaction']);
     }
 
     public function testNackVersionTwo()


### PR DESCRIPTION
Stomp 1.1 requires that the subscription identifier is included in the headers for ACK and NACK requests:

https://stomp.github.io/stomp-specification-1.1.html#ACK