### PR TITLE
add headers getter in Frame class

### DIFF
--- a/src/Stomp/Transport/Frame.php
+++ b/src/Stomp/Transport/Frame.php
@@ -151,6 +151,15 @@ class Frame implements ArrayAccess
         return $this->body;
     }
 
+    /**
+     * Headers
+     *
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
 
     /**
      * Convert frame to transportable string


### PR DESCRIPTION
Hi!

In a proyect I need access to the headers of a message, so I will like to add a `getHeaders()` method in the `Frame` class, analog to the `getBody()` method.