### PR TITLE
Make the library compatible with HHVM Repo Authoritative mode

### DIFF
--- a/src/Stomp/Protocol/Protocol.php
+++ b/src/Stomp/Protocol/Protocol.php
@@ -73,7 +73,7 @@ class Protocol
         $frame->legacyMode(true);
 
         if ($login || $passcode) {
-            $frame->addHeaders(compact('login', 'passcode'));
+            $frame->addHeaders(['login' => $login, 'passcode' => $passcode]);
         }
 
         if ($this->hasClientId()) {

--- a/src/Stomp/States/ProducerState.php
+++ b/src/Stomp/States/ProducerState.php
@@ -39,7 +39,7 @@ class ProducerState extends StateTemplate
     {
         return $this->setState(
             new ConsumerState($this->getClient(), $this->getBase()),
-            compact('destination', 'selector', 'ack', 'header')
+            ['destination' => $destination, 'selector' => $selector, 'ack' => $ack, 'header' => $header]
         );
     }
 

--- a/src/Stomp/States/ProducerTransactionState.php
+++ b/src/Stomp/States/ProducerTransactionState.php
@@ -55,7 +55,7 @@ class ProducerTransactionState extends ProducerState
     {
         return $this->setState(
             new ConsumerTransactionState($this->getClient(), $this->getBase()),
-            $this->getOptions() + compact('destination', 'selector', 'ack', 'header')
+            $this->getOptions() + ['destination' => $destination, 'selector' => $selector, 'ack' => $ack, 'header' => $header]
         );
     }
 


### PR DESCRIPTION
The HHVM Repo Authoritative mode provides significant performance improvements due to pre-optimization. However a few PHP functions can't be used, and one of them is 'compact'.
(It's not [documented](https://docs.hhvm.com/hhvm/advanced-usage/repo-authoritative#tradeoffs) very well, but see https://github.com/facebook/hhvm/issues/2973 - in practice, it doesn't work)

This PR replaces the calls to 'compact' with their array literal equivalents.