### PR TITLE
Feature/message type handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,8 @@ Changelog stomp-php
 4.1.5
 -----
 - fix for false exceptions in combination with pcntl_signal (https://github.com/stomp-php/stomp-php/pull/65)
+
+4.2.0
+-----
+- fix invalid class hierarchy for `Stomp\Transport\Map` changed parent from `Frame` to `Message`
+- add option to register own message type handlers in `Stomp\Transport\FrameFactory` (https://github.com/stomp-php/stomp-php/pull/64)

--- a/src/Stomp/Transport/FrameFactory.php
+++ b/src/Stomp/Transport/FrameFactory.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Transport;
+
+/**
+ * FrameFactory defines how new frames are created after the frame details have been extracted.
+ *
+ * @package Stomp\Transport
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
+ */
+class FrameFactory
+{
+    /**
+     * @var callable[]
+     */
+    private $resolver = [];
+
+    /**
+     * FrameFactory constructor.
+     */
+    public function __construct()
+    {
+        // register default additional builtin resolvers
+        $this->resolver[] =
+            function ($command, array $headers, $body) {
+                if (isset($headers['transformation']) && strcasecmp($headers['transformation'], 'jms-map-json') == 0) {
+                    return new Map($body, $headers, $command);
+                }
+            };
+    }
+
+
+    /**
+     * Creates a frame instance out of the given frame details.
+     *
+     * @param string $command
+     * @param array $headers
+     * @param string $body
+     * @param boolean $legacyMode stomp 1.0 mode (headers)
+     * @return Frame
+     */
+    public function createFrame($command, array $headers, $body, $legacyMode)
+    {
+        foreach ($this->resolver as $resolver) {
+            if ($frame = $resolver($command, $headers, $body, $legacyMode)) {
+                return $frame;
+            }
+        }
+        return $this->defaultFrame($command, $headers, $body, $legacyMode);
+    }
+
+    /**
+     * Creates a new default frame instance.
+     *
+     * @param string $command
+     * @param array $headers
+     * @param string $body
+     * @param boolean $legacyMode
+     * @return Frame
+     */
+    private function defaultFrame($command, array $headers, $body, $legacyMode)
+    {
+        $frame = new Frame($command, $headers, $body);
+        $frame->legacyMode($legacyMode);
+        return $frame;
+    }
+
+    /**
+     * Register a new resolver inside this frame factory.
+     *
+     * The new resolver becomes the first one which will be used to handle the frame create request.
+     * The resolver must return null/false if he won't create a frame for the request.
+     *
+     * @param callable $callable
+     * @return FrameFactory
+     */
+    public function registerResolver($callable)
+    {
+        array_unshift($this->resolver, $callable);
+        return $this;
+    }
+}

--- a/src/Stomp/Transport/Map.php
+++ b/src/Stomp/Transport/Map.php
@@ -21,20 +21,30 @@ class Map extends Message
     /**
      * Constructor
      *
-     * @param Frame|string $msg
+     * @param array|object|string $body string will get decoded (receive), otherwise the body will be encoded (send)
      * @param array $headers
+     * @param string $command
      */
-    public function __construct($msg, array $headers = [])
+    public function __construct($body, array $headers = [], $command = 'SEND')
     {
-        if ($msg instanceof Frame) {
-            parent::__construct($msg->body, $msg->headers);
-            $this->command = $msg->command;
-            $this->map = json_decode($msg->body, true);
+        if (is_string($body)) {
+            parent::__construct($body, $headers);
+            $this->command = $command;
+            $this->map = json_decode($body, true);
         } else {
-            parent::__construct($msg, $headers);
-            $this['transformation'] = 'jms-map-json';
-            $this->body = json_encode($msg);
-            $this->command = 'SEND';
+            parent::__construct(json_encode($body), $headers + ['transformation' => 'jms-map-json']);
+            $this->command = $command;
+            $this->map = $body;
         }
+    }
+
+    /**
+     * Returns the received decoded json.
+     *
+     * @return mixed
+     */
+    public function getMap()
+    {
+        return $this->map;
     }
 }

--- a/src/Stomp/Transport/Map.php
+++ b/src/Stomp/Transport/Map.php
@@ -14,7 +14,7 @@ namespace Stomp\Transport;
  *
  * @package Stomp
  */
-class Map extends Frame
+class Map extends Message
 {
     public $map;
 
@@ -27,12 +27,14 @@ class Map extends Frame
     public function __construct($msg, array $headers = [])
     {
         if ($msg instanceof Frame) {
-            parent::__construct($msg->command, $msg->headers, $msg->body);
+            parent::__construct($msg->body, $msg->headers);
+            $this->command = $msg->command;
             $this->map = json_decode($msg->body, true);
         } else {
-            parent::__construct('SEND', $headers, $msg);
+            parent::__construct($msg, $headers);
             $this['transformation'] = 'jms-map-json';
             $this->body = json_encode($msg);
+            $this->command = 'SEND';
         }
     }
 }

--- a/tests/Unit/Stomp/Transport/FrameFactoryTest.php
+++ b/tests/Unit/Stomp/Transport/FrameFactoryTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Tests\Unit\Stomp\Transport;
+
+use PHPUnit_Framework_TestCase;
+use Stomp\Transport\Frame;
+use Stomp\Transport\FrameFactory;
+use Stomp\Transport\Map;
+
+/**
+ * FrameTest
+ *
+ * @package Stomp\Tests\Unit\Stomp
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
+ */
+class FrameFactoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FrameFactory
+     */
+    private $instance;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->instance = new FrameFactory();
+    }
+
+    public function testFrameFactoryWillCreateDefaultFrames()
+    {
+        $frame = $this->instance->createFrame('COMMAND', ['header1' => true, "header2" => 2], 'BODY', true);
+        $this->assertEquals('COMMAND', $frame->getCommand());
+        $this->assertEquals(['header1' => true, "header2" => 2], $frame->getHeaders());
+        $this->assertEquals('BODY', $frame->getBody());
+        $this->assertTrue($frame->isLegacyMode());
+        $this->assertInstanceOf(Frame::class, $frame);
+    }
+
+    public function testFrameFactoryWillCreateMapInstances()
+    {
+        $frame = $this->instance->createFrame(
+            'MESSAGE',
+            ['transformation' => 'jms-map-json'],
+            json_encode(['key-1' => 'val-2', 'key-2' => 'val-2']),
+            false
+        );
+
+        $this->assertInstanceOf(Map::class, $frame);
+        $this->assertEquals('MESSAGE', $frame->getCommand());
+        $this->assertEquals(['transformation' => 'jms-map-json'], $frame->getHeaders());
+        $this->assertEquals(['key-1' => 'val-2', 'key-2' => 'val-2'], $frame->getMap());
+        $this->assertFalse($frame->isLegacyMode());
+    }
+
+    public function testFrameFactoryWillUseDefaultResolverAsFallback()
+    {
+        $calls = 0;
+        $this->instance->registerResolver(
+            function () use (&$calls) {
+                $calls++;
+            }
+        );
+        $frame = $this->instance->createFrame('MESSAGE', [], 'BODY', false);
+        $this->assertInstanceOf(Frame::class, $frame);
+        $this->assertEquals(1, $calls, 'Custom resolver must have been called.');
+    }
+
+    public function testFrameFactoryWillApplyResolversInReverseOrder()
+    {
+        $resolver = [];
+        $this->instance->registerResolver(
+            function () use (&$resolver) {
+                $resolver[] = 1;
+            }
+        );
+        $this->instance->registerResolver(
+            function () use (&$resolver) {
+                $resolver[] = 2;
+            }
+        );
+
+        $frame = $this->instance->createFrame('MESSAGE', [], 'BODY', false);
+        $this->assertInstanceOf(Frame::class, $frame);
+        $this->assertEquals([2, 1], $resolver, 'Custom resolver must have been called in reverse order.');
+    }
+
+
+    public function testCustomResolverResultWillBeUsedIfPossible()
+    {
+        $this->instance->registerResolver(
+            function ($command, $headers, $body) {
+                return new Frame($command . '-modified', $headers + ['modified' => true], $body . '-modified');
+            }
+        );
+
+        $frame = $this->instance->createFrame('MESSAGE', [], 'BODY', false);
+        $this->assertInstanceOf(Frame::class, $frame);
+        $this->assertEquals('MESSAGE-modified', $frame->getCommand());
+        $this->assertEquals('BODY-modified', $frame->getBody());
+        $this->assertTrue($frame['modified']);
+    }
+}

--- a/tests/Unit/Stomp/Transport/MapTest.php
+++ b/tests/Unit/Stomp/Transport/MapTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Tests\Unit\Stomp\Transport;
+
+use PHPUnit_Framework_TestCase;
+use stdClass;
+use Stomp\Transport\Map;
+
+/**
+ * MapTest
+ *
+ * @package Stomp\Tests\Unit\Stomp
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
+ */
+class MapTest extends PHPUnit_Framework_TestCase
+{
+    public function testMapWillCreateJmsMapJsonIfObjectIsPassed()
+    {
+        $body = new stdClass();
+        $body->property = true;
+        $map = new Map($body);
+
+        $this->assertEquals('SEND', $map->getCommand());
+        $this->assertEquals('jms-map-json', $map['transformation']);
+        $this->assertEquals(json_encode($body), $map->getBody());
+        $this->assertSame($body, $map->getMap());
+    }
+
+    public function testMapWillCreateJmsMapJsonIfArrayIsPassed()
+    {
+        $body = ['property' => true];
+        $map = new Map($body);
+        $this->assertEquals('SEND', $map->getCommand());
+        $this->assertEquals('jms-map-json', $map['transformation']);
+        $this->assertEquals(json_encode($body), $map->getBody());
+        $this->assertSame($body, $map->getMap());
+    }
+
+    public function testMapWillDecodeJsonIfStringIsPassed()
+    {
+        $body = json_encode(['property' => true]);
+        $map = new Map($body, ['transformation' => 'jms-map-json'], 'MESSAGE');
+
+        $this->assertEquals('MESSAGE', $map->getCommand());
+        $this->assertEquals('jms-map-json', $map['transformation']);
+        $this->assertEquals($body, $map->getBody());
+        $this->assertEquals(['property' => true], $map->getMap());
+    }
+}


### PR DESCRIPTION
Some days ago I was using our stomp library again and found out that it's quite complicated to register own message types.

I added the `FrameFactory` which gives access to the logic that was previously inside `setFrame`. Now it's possible to register own resolver  which allows to register domain specific messages.