### PR TITLE
fix for false exceptions in combination with pcntl_signal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jdk:
   
 before_script:
   - sudo apt-get update
-  - sudo apt-get install -y --force-yes erlang
+  - sudo apt-get install -y --force-yes --no-install-recommends erlang
   - phpenv config-rm xdebug.ini; true
   - ./travisci/bin/ci/setup.sh
   - composer install

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,9 @@
         <testsuite name="stomp-php Functional Test Suite">
             <directory>tests/Functional/</directory>
         </testsuite>
+        <testsuite name="stomp-php Special Test Cases Suite">
+            <directory>tests/Cases/</directory>
+        </testsuite>
         <testsuite name="stomp-php Unit Test Suite">
             <directory>tests/Unit/</directory>
         </testsuite>

--- a/tests/Cases/PCNTL/Consumer.php
+++ b/tests/Cases/PCNTL/Consumer.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Tests\Cases\PCNTL;
+
+use Exception;
+use Stomp\Client;
+use Stomp\Network\Connection;
+use Stomp\StatefulStomp;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+
+/**
+ * ConsumerPCNTLTestCase a simulated long running cosumer which is capable of signal handling.
+ *
+ * @package Stomp\Tests\Cases\PCNTL
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
+ */
+class ConsumerPCNTLTestCase
+{
+    private $stomp;
+    private $stopSignalled = false;
+
+    const MAX_RUNTIME = 4;
+
+    /**
+     * ConsumerPCNTLTestCase constructor.
+     */
+    public function __construct()
+    {
+        $this->stomp = new StatefulStomp(new Client(new Connection('tcp://127.0.0.1:61010')));
+    }
+
+
+    /**
+     * Starts the long running consumer process.
+     *
+     * Will only return true if the process was stopped by a signal.
+     *
+     * @return bool
+     */
+    public function testRegisteredAndTriggeredSignalHandlerWontLeadToConnectionException()
+    {
+        $this->registerListeners();
+        $this->stomp->subscribe('/queue/test');
+        $this->stomp->getClient()->getConnection()->setReadTimeout(0, 50000);
+        echo 'INFO: Started to listen for new messages...', PHP_EOL;
+        $time = @time();
+        while ((@time() - $time) < self::MAX_RUNTIME && (!$this->stopSignalled)) {
+            try {
+                pcntl_signal_dispatch();
+                $this->stomp->read();
+            } catch (Exception $exception) {
+                echo 'FAILED: Received an unexpected exception: ', $exception->getMessage(), PHP_EOL;
+                return false;
+            }
+        }
+
+
+        if (!$this->stopSignalled) {
+            echo 'FAILED: The stop signal was not received!', PHP_EOL;
+            return false;
+        }
+        return true;
+    }
+
+
+    private function registerListeners()
+    {
+        pcntl_signal(SIGUSR1, [$this, 'onSignal']);
+    }
+
+
+    private function onSignal()
+    {
+        $this->stopSignalled = true;
+    }
+}
+
+
+$signalTest = new ConsumerPCNTLTestCase();
+if (!$signalTest->testRegisteredAndTriggeredSignalHandlerWontLeadToConnectionException()) {
+    echo 'TEST: FAILED', PHP_EOL;
+    exit(1);
+} else {
+    echo 'TEST: SUCCEEDED', PHP_EOL;
+    exit(0);
+}

--- a/tests/Cases/PCNTL/StreamSignalTest.php
+++ b/tests/Cases/PCNTL/StreamSignalTest.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Tests\Cases\PCNTL;
+
+use PHPUnit_Framework_TestCase;
+
+/**
+ * StreamSignalTest
+ *
+ * @package Stomp\Tests\Cases\PCNTL
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
+ */
+class StreamSignalTest extends PHPUnit_Framework_TestCase
+{
+    public function testSignaledWontBreakStreamSelect()
+    {
+        if (!extension_loaded('pcntl')) {
+            $this->markTestSkipped('The pcntl extension is required to run this test case.');
+        }
+        $descriptorspec = [
+            0 => ["pipe", "r"],
+            1 => ["pipe", "w"],
+            2 => ["pipe", "w"]
+        ];
+
+        $process = proc_open(
+            sprintf(
+                'exec %s %s',
+                PHP_BINARY,
+                realpath(__DIR__ . '/Consumer.php')
+            ),
+            $descriptorspec,
+            $pipes
+        );
+
+        // give new process some time to start listening
+        usleep(750000);
+
+        $status = proc_get_status($process);
+
+        $this->assertTrue($status['running']);
+        $this->assertTrue(posix_kill($status['pid'], SIGUSR1));
+
+        // give process some time to trigger a signal handler
+        usleep(100000);
+
+
+        $output = stream_get_contents($pipes[1]);
+        $this->assertEmpty(stream_get_contents($pipes[2]));
+        fclose($pipes[0]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $returnCode = proc_close($process);
+        $this->assertContains('INFO: Started to listen for new messages...', $output);
+        $this->assertContains('TEST: SUCCEEDED', $output);
+        $this->assertEquals(0, $returnCode);
+    }
+}


### PR DESCRIPTION
I created a long running consumer which makes use of `pcntl_signal`. When it comes to new signals while we're in `stream_select` this will return false and provoke a connection exception, even if there is no connection problem.