### PR TITLE
Update Connector to support _ in the broker uri

### DIFF
--- a/src/Stomp/Network/Connection.php
+++ b/src/Stomp/Network/Connection.php
@@ -125,7 +125,7 @@ class Connection
         $this->parser = new Parser();
         $this->connectTimeout = $connectionTimeout;
         $this->context = $context;
-        $pattern = "|^(([a-zA-Z0-9]+)://)+\(*([a-zA-Z0-9\.:/i,-_]+)\)*\??([a-zA-Z0-9=&_]*)$|i";
+        $pattern = "|^(([a-zA-Z0-9]+)://)+\(*([a-zA-Z0-9\.:/i,-_]+)\)*\??([a-zA-Z0-9=&]*)$|i";
         if (preg_match($pattern, $brokerUri, $matches)) {
             $scheme = $matches[2];
             $hosts = $matches[3];

--- a/src/Stomp/Network/Connection.php
+++ b/src/Stomp/Network/Connection.php
@@ -125,7 +125,7 @@ class Connection
         $this->parser = new Parser();
         $this->connectTimeout = $connectionTimeout;
         $this->context = $context;
-        $pattern = "|^(([a-zA-Z0-9]+)://)+\(*([a-zA-Z0-9\.:/i,-]+)\)*\??([a-zA-Z0-9=&]*)$|i";
+        $pattern = "|^(([a-zA-Z0-9]+)://)+\(*([a-zA-Z0-9\.:/i,-_]+)\)*\??([a-zA-Z0-9=&_]*)$|i";
         if (preg_match($pattern, $brokerUri, $matches)) {
             $scheme = $matches[2];
             $hosts = $matches[3];

--- a/tests/Unit/Stomp/Network/ConnectionTest.php
+++ b/tests/Unit/Stomp/Network/ConnectionTest.php
@@ -50,6 +50,18 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(61613, $host['port'], 'Default port must be set!');
     }
 
+    public function testBrokerUriParseUnderscoreInHost()
+    {
+        $connection = new Connection('tcp://host_test');
+        $getHostList = new ReflectionMethod($connection, 'getHostList');
+        $getHostList->setAccessible(true);
+
+        $hostList = $getHostList->invoke($connection);
+        $host = array_shift($hostList);
+        $this->assertEquals('tcp', $host['scheme']);
+        $this->assertEquals('host_test', $host['host']);
+    }
+
     public function testBrokerUriParseSpecificPort()
     {
         $connection = new Connection('tcp://host1:55');


### PR DESCRIPTION
Support underscore in the failover host name and parameters in the url. This issue provokes that if you are using docker and the systems are generated automatically it doesn't work because of the _