### PR TITLE
Fix: Remove unnecessary property initializations

### DIFF
--- a/src/Broker/Apollo/Mode/SequenceQueueBrowser.php
+++ b/src/Broker/Apollo/Mode/SequenceQueueBrowser.php
@@ -40,7 +40,7 @@ class SequenceQueueBrowser extends QueueBrowser
      *
      * @var null|int
      */
-    private $seq = null;
+    private $seq;
 
     /**
      * SequenceQueueBrowser constructor.

--- a/src/Client.php
+++ b/src/Client.php
@@ -44,7 +44,7 @@ class Client
      *
      * @var string
      */
-    private $clientId = null;
+    private $clientId;
 
     /**
      * Connection session id
@@ -83,13 +83,13 @@ class Client
      *
      * @var string
      */
-    private $login = null;
+    private $login;
 
     /**
      *
      * @var string
      */
-    private $passcode = null;
+    private $passcode;
 
 
     /**
@@ -102,7 +102,7 @@ class Client
      *
      * @var string
      */
-    private $host = null;
+    private $host;
 
     /**
      *

--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -76,7 +76,7 @@ class Connection
      *
      * @var resource
      */
-    private $connection = null;
+    private $connection;
 
     /**
      * Connected host info.

--- a/src/Network/Observer/HeartbeatEmitter.php
+++ b/src/Network/Observer/HeartbeatEmitter.php
@@ -40,28 +40,28 @@ class HeartbeatEmitter implements ConnectionObserver
      *
      * @var float
      */
-    private $lastbeat = null;
+    private $lastbeat;
 
     /**
      * The beat interval that the client has offered to the server.
      *
      * @var integer
      */
-    private $intervalClient = null;
+    private $intervalClient;
 
     /**
      * The beat interval that the server has requested for this connection.
      *
      * @var integer
      */
-    private $intervalServer = null;
+    private $intervalServer;
 
     /**
      * The interval that will be used to send beats.
      *
      * @var float
      */
-    private $interval = null;
+    private $interval;
 
     /**
      * Whenever the emitter is configured to send beats.

--- a/src/Transport/Parser.php
+++ b/src/Transport/Parser.php
@@ -31,14 +31,14 @@ class Parser
      *
      * @var Frame
      */
-    private $frame = null;
+    private $frame;
 
     /**
      * Active Frame command
      *
      * @var string
      */
-    private $command = null;
+    private $command;
 
     /**
      * Active Frame headers
@@ -52,7 +52,7 @@ class Parser
      *
      * @var integer
      */
-    private $expectedBodyLength = null;
+    private $expectedBodyLength;
 
     /**
      * Parser mode


### PR DESCRIPTION
This PR

* [x] removes unnecessary property initializations

💁‍♂️ `null` is the default, so there's no need to explicitly assign it to these properties.