### PR TITLE
Fix: Remove unnecessary parentheses

### DIFF
--- a/tests/Functional/ApolloMq/Mode/QueueBrowserTest.php
+++ b/tests/Functional/ApolloMq/Mode/QueueBrowserTest.php
@@ -78,7 +78,7 @@ class QueueBrowserTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($browser->hasReachedEnd());
 
         $producer = ClientProvider::getClient();
-        $producer->send(self::$queue, new Message('message-6', ['expires' => (self::$expires + 20000)]));
+        $producer->send(self::$queue, new Message('message-6', ['expires' => self::$expires + 20000]));
         $producer->disconnect(true);
 
         $frame = $browser->read();

--- a/tests/Functional/ApolloMq/Mode/SequenceQueueBrowserTest.php
+++ b/tests/Functional/ApolloMq/Mode/SequenceQueueBrowserTest.php
@@ -96,7 +96,7 @@ class SequenceQueueBrowserTest extends PHPUnit_Framework_TestCase
         $browser->subscribe();
 
         $producer = ClientProvider::getClient();
-        $producer->send(self::$queue, new Message('message-6', ['expires' => (self::$expires + 20000)]));
+        $producer->send(self::$queue, new Message('message-6', ['expires' => self::$expires + 20000]));
         $producer->disconnect(true);
 
         $frame = $browser->read();


### PR DESCRIPTION
This PR

* [x] removes unnecessary parentheses