### PR TITLE
Fix: Rename test class to map to tested class

### DIFF
--- a/tests/Unit/Stomp/StatefulStompTest.php
+++ b/tests/Unit/Stomp/StatefulStompTest.php
@@ -27,7 +27,7 @@ use Stomp\Transport\Message;
  * @package Stomp\Tests\Unit\Stomp
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class StatefulTest extends PHPUnit_Framework_TestCase
+class StatefulStompTest extends PHPUnit_Framework_TestCase
 {
 
     public function testInitialStateIsProducer()


### PR DESCRIPTION
This PR

* [x] renames a test class to map to the tested class

💁‍♂️ Appears that the system under test is an instance of `StatefulStomp`, so the test class should probably be called `StatefulStompTest`.