### PR TITLE
Fix: Remove useless elseif

### DIFF
--- a/src/Protocol/Version.php
+++ b/src/Protocol/Version.php
@@ -73,11 +73,14 @@ class Version
         $version = $this->getVersion();
         if (stristr($server, 'rabbitmq') !== false) {
             return new RabbitMq($clientId, $version, $server);
-        } elseif (stristr($server, 'apache-apollo') !== false) {
+        }
+        if (stristr($server, 'apache-apollo') !== false) {
             return new Apollo($clientId, $version, $server);
-        } elseif (stristr($server, 'activemq') !== false) {
+        }
+        if (stristr($server, 'activemq') !== false) {
             return new ActiveMq($clientId, $version, $server);
-        } elseif (stristr($server, 'open message queue') !== false) {
+        }
+        if (stristr($server, 'open message queue') !== false) {
             return new OpenMq($clientId, $version, $server);
         }
         return new Protocol($clientId, $version, $server);

--- a/src/Transport/Parser.php
+++ b/src/Transport/Parser.php
@@ -224,7 +224,9 @@ class Parser
             $this->extractFrameMeta(substr($this->buffer, $this->offset, $headerEnd - $this->offset));
             $this->offset = $headerEnd + strlen(self::HEADER_STOP_CR_LF);
             return true;
-        } elseif (($headerEnd = strpos($this->buffer, self::HEADER_STOP_LF, $this->offset)) !== false) {
+        }
+
+        if (($headerEnd = strpos($this->buffer, self::HEADER_STOP_LF, $this->offset)) !== false) {
             $this->extractFrameMeta(substr($this->buffer, $this->offset, $headerEnd - $this->offset));
             $this->offset = $headerEnd + strlen(self::HEADER_STOP_LF);
             return true;


### PR DESCRIPTION
This PR

* [x] removes useless `elseif`

💁‍♂️ No need for an `elseif` if we `return` already!