### PR TITLE
Fix: Use forward compatibility layer of phpunit/phpunit

### DIFF
--- a/tests/Cases/PCNTL/StreamSignalTest.php
+++ b/tests/Cases/PCNTL/StreamSignalTest.php
@@ -8,7 +8,7 @@
 
 namespace Stomp\Tests\Cases\PCNTL;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * StreamSignalTest
@@ -16,7 +16,7 @@ use PHPUnit_Framework_TestCase;
  * @package Stomp\Tests\Cases\PCNTL
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class StreamSignalTest extends PHPUnit_Framework_TestCase
+class StreamSignalTest extends TestCase
 {
     public function testSignaledWontBreakStreamSelect()
     {

--- a/tests/Functional/ActiveMq/ASyncTest.php
+++ b/tests/Functional/ActiveMq/ASyncTest.php
@@ -9,7 +9,7 @@
 
 namespace Stomp\Tests\Functional\ActiveMq;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Client;
 use Stomp\SimpleStomp;
 
@@ -19,7 +19,7 @@ use Stomp\SimpleStomp;
  * @package Stomp
  * @author Mark R. <mark+gh@mark.org.il>
  */
-class ASyncTest extends PHPUnit_Framework_TestCase
+class ASyncTest extends TestCase
 {
     /**
      * @var Client

--- a/tests/Functional/ActiveMq/ActiveMqFunctionalTestCase.php
+++ b/tests/Functional/ActiveMq/ActiveMqFunctionalTestCase.php
@@ -8,7 +8,7 @@
 
 namespace Stomp\Tests\Functional\ActiveMq;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Client;
 use Stomp\SimpleStomp;
 use Stomp\Transport\Frame;
@@ -19,7 +19,7 @@ use Stomp\Transport\Frame;
  * @package Stomp\Tests\Functional\ActiveMq
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-abstract class ActiveMqFunctionalTestCase extends PHPUnit_Framework_TestCase
+abstract class ActiveMqFunctionalTestCase extends TestCase
 {
 
     /**

--- a/tests/Functional/ActiveMq/ClientTest.php
+++ b/tests/Functional/ActiveMq/ClientTest.php
@@ -9,7 +9,7 @@
 
 namespace Stomp\Tests\Functional\ActiveMq;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Broker\ActiveMq\ActiveMq;
 use Stomp\Client;
 use Stomp\Network\Observer\HeartbeatEmitter;
@@ -25,7 +25,7 @@ use Stomp\Transport\Map;
  * @author Michael Caplan <mcaplan@labnet.net>
  * @author Dejan Bosanac <dejan@nighttale.net>
  */
-class ClientTest extends PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /**
      * @var SimpleStomp

--- a/tests/Functional/ActiveMq/SyncTest.php
+++ b/tests/Functional/ActiveMq/SyncTest.php
@@ -9,6 +9,7 @@
 
 namespace Stomp\Tests\Functional\ActiveMq;
 
+use PHPUnit\Framework\TestCase;
 use Stomp\Client;
 use Stomp\SimpleStomp;
 use Stomp\Transport\Frame;
@@ -19,7 +20,7 @@ use Stomp\Transport\Frame;
  * @package Stomp
  * @author Mark R. <mark+gh@mark.org.il>
   */
-class SyncTest extends \PHPUnit_Framework_TestCase
+class SyncTest extends TestCase
 {
     /**
      * @var SimpleStomp

--- a/tests/Functional/ApolloMq/ClientTest.php
+++ b/tests/Functional/ApolloMq/ClientTest.php
@@ -9,7 +9,7 @@
 
 namespace Stomp\Tests\Functional\ApolloMq;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Broker\Apollo\Apollo;
 
 /**
@@ -18,7 +18,7 @@ use Stomp\Broker\Apollo\Apollo;
  * @package Stomp\Tests\Functional\ApolloMq
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class ClientTest extends PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /**
      * @var \Stomp\Client

--- a/tests/Functional/ApolloMq/Mode/QueueBrowserTest.php
+++ b/tests/Functional/ApolloMq/Mode/QueueBrowserTest.php
@@ -8,7 +8,7 @@
 
 namespace Stomp\Tests\Functional\ApolloMq\Mode;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Broker\Apollo\Mode\QueueBrowser;
 use Stomp\Tests\Functional\ApolloMq\ClientProvider;
 use Stomp\Transport\Frame;
@@ -20,7 +20,7 @@ use Stomp\Transport\Message;
  * @package Stomp\Tests\Functional\ApolloMq\Mode
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class QueueBrowserTest extends PHPUnit_Framework_TestCase
+class QueueBrowserTest extends TestCase
 {
 
     public static function setUpBeforeClass()

--- a/tests/Functional/ApolloMq/Mode/SequenceQueueBrowserTest.php
+++ b/tests/Functional/ApolloMq/Mode/SequenceQueueBrowserTest.php
@@ -8,7 +8,7 @@
 
 namespace Stomp\Tests\Functional\ApolloMq\Mode;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Broker\Apollo\Mode\SequenceQueueBrowser;
 use Stomp\Tests\Functional\ApolloMq\ClientProvider;
 use Stomp\Transport\Frame;
@@ -20,7 +20,7 @@ use Stomp\Transport\Message;
  * @package Stomp\Tests\Functional\ApolloMq\Mode
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class SequenceQueueBrowserTest extends PHPUnit_Framework_TestCase
+class SequenceQueueBrowserTest extends TestCase
 {
 
     public static function setUpBeforeClass()

--- a/tests/Functional/Generic/ConnectionTest.php
+++ b/tests/Functional/Generic/ConnectionTest.php
@@ -9,6 +9,7 @@
 
 namespace Stomp\Tests\Functional\Generic;
 
+use PHPUnit\Framework\TestCase;
 use Stomp\Exception\ConnectionException;
 use Stomp\Exception\ErrorFrameException;
 use Stomp\Network\Connection;
@@ -19,7 +20,7 @@ use Stomp\Transport\Frame;
  * @package Stomp
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class ConnectionTest extends \PHPUnit_Framework_TestCase
+class ConnectionTest extends TestCase
 {
     public function testReadFrameThrowsExceptionIfStreamIsBroken()
     {

--- a/tests/Functional/Generic/StompFailoverTest.php
+++ b/tests/Functional/Generic/StompFailoverTest.php
@@ -9,6 +9,7 @@
 
 namespace Stomp\Tests\Functional\Generic;
 
+use PHPUnit\Framework\TestCase;
 use Stomp\Client;
 
 /**
@@ -17,7 +18,7 @@ use Stomp\Client;
  * @package Stomp
  * @author Michael Caplan <mcaplan@labnet.net>
  */
-class StompFailoverTest extends \PHPUnit_Framework_TestCase
+class StompFailoverTest extends TestCase
 {
     /**
      * @var Client

--- a/tests/Functional/RabbitMq/ClientTest.php
+++ b/tests/Functional/RabbitMq/ClientTest.php
@@ -9,7 +9,7 @@
 
 namespace Stomp\Tests\Functional\RabbitMq;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Client;
 use Stomp\SimpleStomp;
 use Stomp\Transport\Bytes;
@@ -23,7 +23,7 @@ use Stomp\Transport\Map;
  * @author Michael Caplan <mcaplan@labnet.net>
  * @author Dejan Bosanac <dejan@nighttale.net>
  */
-class ClientTest extends PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /**
      * @var Client

--- a/tests/Functional/Stomp/StatefulTestBase.php
+++ b/tests/Functional/Stomp/StatefulTestBase.php
@@ -8,7 +8,7 @@
 
 namespace Stomp\Tests\Functional\Stomp;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Client;
 use Stomp\StatefulStomp;
 use Stomp\Transport\Frame;
@@ -21,7 +21,7 @@ use Stomp\Transport\Message;
  * @package Stomp\Tests\Functional\Stomp
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-abstract class StatefulTestBase extends PHPUnit_Framework_TestCase
+abstract class StatefulTestBase extends TestCase
 {
     /**
      * @var Client[]

--- a/tests/Unit/Broker/ActiveMq/Mode/ActiveMqModeTest.php
+++ b/tests/Unit/Broker/ActiveMq/Mode/ActiveMqModeTest.php
@@ -8,7 +8,7 @@
 
 namespace Stomp\Tests\Unit\Broker\ActiveMq\Mode;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Stomp\Broker\ActiveMq\Mode\ActiveMqMode;
 use Stomp\Broker\RabbitMq\RabbitMq;
@@ -20,7 +20,7 @@ use Stomp\Client;
  * @package Stomp\Tests\Unit\Broker\ActiveMq\Mode
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class ActiveMqModeTest extends PHPUnit_Framework_TestCase
+class ActiveMqModeTest extends TestCase
 {
     /**
      * @expectedException \Stomp\Broker\Exception\UnsupportedBrokerException

--- a/tests/Unit/Broker/ActiveMq/Mode/DurableSubscriptionTest.php
+++ b/tests/Unit/Broker/ActiveMq/Mode/DurableSubscriptionTest.php
@@ -8,7 +8,7 @@
 
 namespace Stomp\Tests\Unit\Broker\ActiveMq\Mode;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Broker\ActiveMq\Mode\DurableSubscription;
 use Stomp\Client;
 
@@ -18,7 +18,7 @@ use Stomp\Client;
  * @package Stomp\Tests\Unit\Broker\ActiveMq\Mode
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class DurableSubscriptionTest extends PHPUnit_Framework_TestCase
+class DurableSubscriptionTest extends TestCase
 {
     /**
      * @expectedException \Stomp\Exception\StompException

--- a/tests/Unit/Broker/Apollo/Mode/QueueBrowserTest.php
+++ b/tests/Unit/Broker/Apollo/Mode/QueueBrowserTest.php
@@ -8,7 +8,7 @@
 
 namespace Stomp\Tests\Unit\Broker\Apollo\Mode;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Broker\Apollo\Mode\QueueBrowser;
 use Stomp\Broker\RabbitMq\RabbitMq;
 use Stomp\Client;
@@ -19,7 +19,7 @@ use Stomp\Client;
  * @package Stomp\Tests\Unit\Broker\Apollo\Mode
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class QueueBrowserTest extends PHPUnit_Framework_TestCase
+class QueueBrowserTest extends TestCase
 {
     /**
      * @expectedException \Stomp\Broker\Exception\UnsupportedBrokerException

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -9,7 +9,7 @@
 
 namespace Stomp\Tests\Unit;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Stomp\Broker\RabbitMq\RabbitMq;
 use Stomp\Client;
@@ -30,7 +30,7 @@ use Stomp\Transport\Parser;
  * @package Stomp
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class ClientTest extends PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /**
      * Used to avoid destructor calls within single tests

--- a/tests/Unit/Network/ConnectionTest.php
+++ b/tests/Unit/Network/ConnectionTest.php
@@ -10,7 +10,7 @@
 namespace Stomp\Tests\Unit\Network;
 
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Stomp\Exception\ConnectionException;
 use Stomp\Network\Connection;
@@ -23,7 +23,7 @@ use Stomp\Transport\Frame;
  * @package Stomp
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class ConnectionTest extends PHPUnit_Framework_TestCase
+class ConnectionTest extends TestCase
 {
     public function testBrokerUriParseFailover()
     {

--- a/tests/Unit/Protocol/ProtocolTestCase.php
+++ b/tests/Unit/Protocol/ProtocolTestCase.php
@@ -9,7 +9,7 @@
 
 namespace Stomp\Tests\Unit\Protocol;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Protocol\Protocol;
 use Stomp\Protocol\Version;
 use Stomp\Transport\Frame;
@@ -21,7 +21,7 @@ use Stomp\Exception\StompException;
  * @package Stomp
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-abstract class ProtocolTestCase extends PHPUnit_Framework_TestCase
+abstract class ProtocolTestCase extends TestCase
 {
 
     /**

--- a/tests/Unit/SimpleStompTest.php
+++ b/tests/Unit/SimpleStompTest.php
@@ -8,7 +8,7 @@
 
 namespace Stomp\Tests\Unit;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Client;
 use Stomp\SimpleStomp;
 use Stomp\Protocol\Protocol;
@@ -22,7 +22,7 @@ use Stomp\Transport\Message;
  * @package Stomp\Tests\Unit
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class SimpleStompTest extends PHPUnit_Framework_TestCase
+class SimpleStompTest extends TestCase
 {
 
     public function testSendIsMappedToClient()

--- a/tests/Unit/StatefulStompTest.php
+++ b/tests/Unit/StatefulStompTest.php
@@ -8,7 +8,7 @@
 
 namespace Stomp\Tests\Unit;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Stomp\Client;
 use Stomp\Protocol\Protocol;
@@ -27,7 +27,7 @@ use Stomp\Transport\Message;
  * @package Stomp\Tests\Unit
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class StatefulStompTest extends PHPUnit_Framework_TestCase
+class StatefulStompTest extends TestCase
 {
 
     public function testInitialStateIsProducer()

--- a/tests/Unit/States/ConsumerStateTest.php
+++ b/tests/Unit/States/ConsumerStateTest.php
@@ -8,7 +8,7 @@
 
 namespace Stomp\Tests\Unit\States;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Client;
 use Stomp\StatefulStomp;
 use Stomp\States\ConsumerState;
@@ -19,7 +19,7 @@ use Stomp\States\ConsumerState;
  * @package Stomp\Tests\Unit\States
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class ConsumerStateTest extends PHPUnit_Framework_TestCase
+class ConsumerStateTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/Unit/Transport/FrameFactoryTest.php
+++ b/tests/Unit/Transport/FrameFactoryTest.php
@@ -9,7 +9,7 @@
 
 namespace Stomp\Tests\Unit\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Transport\Frame;
 use Stomp\Transport\FrameFactory;
 use Stomp\Transport\Map;
@@ -20,7 +20,7 @@ use Stomp\Transport\Map;
  * @package Stomp\Tests\Unit
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class FrameFactoryTest extends PHPUnit_Framework_TestCase
+class FrameFactoryTest extends TestCase
 {
     /**
      * @var FrameFactory

--- a/tests/Unit/Transport/FrameTest.php
+++ b/tests/Unit/Transport/FrameTest.php
@@ -9,6 +9,7 @@
 
 namespace Stomp\Tests\Unit\Transport;
 
+use PHPUnit\Framework\TestCase;
 use Stomp\Transport\Frame;
 
 /**
@@ -17,7 +18,7 @@ use Stomp\Transport\Frame;
  * @package Stomp\Tests\Unit
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class FrameTest extends \PHPUnit_Framework_TestCase
+class FrameTest extends TestCase
 {
     /** @test */
     public function shouldConvertFrameToString()

--- a/tests/Unit/Transport/MapTest.php
+++ b/tests/Unit/Transport/MapTest.php
@@ -9,7 +9,7 @@
 
 namespace Stomp\Tests\Unit\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Stomp\Transport\Map;
 
@@ -19,7 +19,7 @@ use Stomp\Transport\Map;
  * @package Stomp\Tests\Unit
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class MapTest extends PHPUnit_Framework_TestCase
+class MapTest extends TestCase
 {
     public function testMapWillCreateJmsMapJsonIfObjectIsPassed()
     {

--- a/tests/Unit/Transport/ParserTest.php
+++ b/tests/Unit/Transport/ParserTest.php
@@ -9,7 +9,7 @@
 
 namespace Stomp\Tests\Unit\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Stomp\Transport\Frame;
 use Stomp\Transport\Map;
 use Stomp\Transport\Parser;
@@ -21,7 +21,7 @@ use Stomp\Transport\Parser;
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  * @coversDefaultClass \Stomp\Transport\Parser
  */
-class ParserTest extends PHPUnit_Framework_TestCase
+class ParserTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
This PR

* [x] makes use of the forward compatibility layer of `phpunit/phpunit`

💁‍♂️ It has been backported to older versions, and it has already been used in this code base. 

Running

```
$ git grep "PHPUnit\\\Framework\\\TestCase"
```

yields

```
tests/Unit/Stomp/Network/Observer/ConnectionObserverCollectionTest.php:12:use PHPUnit\Framework\TestCase;
tests/Unit/Stomp/Network/Observer/HeartbeatEmitterTest.php:12:use PHPUnit\Framework\TestCase;
```