### PR TITLE
Fix: Use expectException() instead of annotations

### DIFF
--- a/tests/Unit/Broker/ActiveMq/Mode/ActiveMqModeTest.php
+++ b/tests/Unit/Broker/ActiveMq/Mode/ActiveMqModeTest.php
@@ -11,6 +11,7 @@ namespace Stomp\Tests\Unit\Broker\ActiveMq\Mode;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Stomp\Broker\ActiveMq\Mode\ActiveMqMode;
+use Stomp\Broker\Exception\UnsupportedBrokerException;
 use Stomp\Broker\RabbitMq\RabbitMq;
 use Stomp\Client;
 
@@ -22,9 +23,6 @@ use Stomp\Client;
  */
 class ActiveMqModeTest extends TestCase
 {
-    /**
-     * @expectedException \Stomp\Broker\Exception\UnsupportedBrokerException
-     */
     public function testGetProtocolWillThrowExceptionIfClientIsNotConnectedToActiveMq()
     {
         $client = $this->getMockBuilder(Client::class)
@@ -38,6 +36,9 @@ class ActiveMqModeTest extends TestCase
 
         $getProtocol = new ReflectionMethod($activeMqMode, 'getProtocol');
         $getProtocol->setAccessible(true);
+
+        $this->expectException(UnsupportedBrokerException::class);
+
         $getProtocol->invoke($activeMqMode);
     }
 }

--- a/tests/Unit/Broker/ActiveMq/Mode/DurableSubscriptionTest.php
+++ b/tests/Unit/Broker/ActiveMq/Mode/DurableSubscriptionTest.php
@@ -11,6 +11,7 @@ namespace Stomp\Tests\Unit\Broker\ActiveMq\Mode;
 use PHPUnit\Framework\TestCase;
 use Stomp\Broker\ActiveMq\Mode\DurableSubscription;
 use Stomp\Client;
+use Stomp\Exception\StompException;
 
 /**
  * DurableSubscriptionTest
@@ -20,11 +21,10 @@ use Stomp\Client;
  */
 class DurableSubscriptionTest extends TestCase
 {
-    /**
-     * @expectedException \Stomp\Exception\StompException
-     */
     public function testDurableSubscriptionIsOnlyPossibleWithClientId()
     {
+        $this->expectException(StompException::class);
+
         new DurableSubscription(new Client('tcp://127.0.0.1'), 'destination');
     }
 }

--- a/tests/Unit/Broker/Apollo/Mode/QueueBrowserTest.php
+++ b/tests/Unit/Broker/Apollo/Mode/QueueBrowserTest.php
@@ -10,6 +10,7 @@ namespace Stomp\Tests\Unit\Broker\Apollo\Mode;
 
 use PHPUnit\Framework\TestCase;
 use Stomp\Broker\Apollo\Mode\QueueBrowser;
+use Stomp\Broker\Exception\UnsupportedBrokerException;
 use Stomp\Broker\RabbitMq\RabbitMq;
 use Stomp\Client;
 
@@ -21,9 +22,6 @@ use Stomp\Client;
  */
 class QueueBrowserTest extends TestCase
 {
-    /**
-     * @expectedException \Stomp\Broker\Exception\UnsupportedBrokerException
-     */
     public function testBrowserWontWorkWithNonApolloBroker()
     {
         $client = $this->getMockBuilder(Client::class)
@@ -36,6 +34,8 @@ class QueueBrowserTest extends TestCase
          * @var $client Client
          */
         $browser = new QueueBrowser($client, 'target');
+
+        $this->expectException(UnsupportedBrokerException::class);
         $browser->subscribe();
     }
 }

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -57,12 +57,12 @@ class ClientTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Stomp\Exception\ConnectionException
-     */
     public function testConnectWillThrowExceptionIfNoFrameWasRead()
     {
         $stomp = $this->getStompWithInjectedMockedConnectionReadResult(false);
+
+        $this->expectException(ConnectionException::class);
+
         $stomp->connect();
     }
 
@@ -155,9 +155,6 @@ class ClientTest extends TestCase
         $this->assertEquals(Version::VERSION_1_0 . ',' . Version::VERSION_1_2, $sendFrame['accept-version']);
     }
 
-    /**
-     * @expectedException \Stomp\Exception\StompException
-     */
     public function testWaitForReceiptWillThrowExceptionOnIdMismatch()
     {
         $receiptFrame = new Frame('RECEIPT');
@@ -167,6 +164,8 @@ class ClientTest extends TestCase
 
         $waitForReceipt = new ReflectionMethod($stomp, 'waitForReceipt');
         $waitForReceipt->setAccessible(true);
+
+        $this->expectException(StompException::class);
 
         // expect a receipt for another id
         $waitForReceipt->invoke($stomp, 'your-id');
@@ -191,10 +190,6 @@ class ClientTest extends TestCase
     }
 
 
-    /**
-     * @expectedException \Stomp\Exception\MissingReceiptException
-     * @expectedExceptionMessage my-expected-receive-id
-     */
     public function testWaitForReceiptWillThrowExceptionIfConnectionReadTimeoutOccurs()
     {
         $stomp = $this->getStompWithInjectedMockedConnectionReadResult(false);
@@ -202,6 +197,9 @@ class ClientTest extends TestCase
 
         $waitForReceipt = new ReflectionMethod($stomp, 'waitForReceipt');
         $waitForReceipt->setAccessible(true);
+
+        $this->expectException(\Stomp\Exception\MissingReceiptException::class);
+        $this->expectExceptionMessage('my-expected-receive-id');
 
         // MuT
         $waitForReceipt->invoke($stomp, 'my-expected-receive-id');

--- a/tests/Unit/Network/ConnectionTest.php
+++ b/tests/Unit/Network/ConnectionTest.php
@@ -13,6 +13,7 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Stomp\Exception\ConnectionException;
+use Stomp\Exception\StompException;
 use Stomp\Network\Connection;
 use Stomp\Tests\Unit\Network\Mocks\FakeStream;
 use Stomp\Transport\Frame;
@@ -75,11 +76,10 @@ class ConnectionTest extends TestCase
         $this->assertEquals(55, $host['port']);
     }
 
-    /**
-     * @expectedException \Stomp\Exception\StompException
-     */
     public function testBrokerUriParseWithEmptyListWillLeadToException()
     {
+        $this->expectException(StompException::class);
+
         new Connection('-');
     }
 
@@ -114,30 +114,30 @@ class ConnectionTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Stomp\Exception\StompException
-     */
     public function testHasDataToReadThrowsExceptionIfNotConnected()
     {
         $connection = new Connection('tcp://localhost');
+
+        $this->expectException(StompException::class);
+
         $connection->hasDataToRead();
     }
 
-    /**
-     * @expectedException \Stomp\Exception\StompException
-     */
     public function testReadFrameThrowsExceptionIfNotConnected()
     {
         $connection = new Connection('tcp://localhost');
+
+        $this->expectException(StompException::class);
+
         $connection->readFrame();
     }
 
-    /**
-     * @expectedException \Stomp\Exception\StompException
-     */
     public function testWriteFrameThrowsExceptionIfNotConnected()
     {
         $connection = new Connection('tcp://localhost');
+
+        $this->expectException(StompException::class);
+
         $connection->writeFrame(new Frame());
     }
 

--- a/tests/Unit/Protocol/ProtocolTestCase.php
+++ b/tests/Unit/Protocol/ProtocolTestCase.php
@@ -85,12 +85,12 @@ abstract class ProtocolTestCase extends TestCase
         $this->assertEquals('my-transaction', $actual['transaction']);
     }
 
-    /**
-     * @expectedException \Stomp\Exception\StompException
-     */
     public function testNackVersionZero()
     {
         $instance = $this->getProtocol(Version::VERSION_1_0);
+
+        $this->expectException(StompException::class);
+
         $instance->getNackFrame(new Frame(null, ['message-id' => 'id-value']));
     }
 

--- a/tests/Unit/States/ConsumerStateTest.php
+++ b/tests/Unit/States/ConsumerStateTest.php
@@ -21,9 +21,6 @@ use Stomp\States\ConsumerState;
  */
 class ConsumerStateTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUnsubscribeWillThrowExceptionIfGivenIdIsNotActive()
     {
         $client = $this->getMockBuilder(Client::class)
@@ -36,6 +33,9 @@ class ConsumerStateTest extends TestCase
          */
         $stateful = new StatefulStomp($client);
         $consumerState = new ConsumerState($client, $stateful);
+
+        $this->expectException(\InvalidArgumentException::class);
+
         $consumerState->unsubscribe('not-existing');
     }
 }


### PR DESCRIPTION
This PR

* [x] uses `expectException()` and its siblings instead of using `@expectedException` annotations

Follows #87.

💁‍♂️ For reference, see https://thephp.cc/news/2016/02/questioning-phpunit-best-practices.