### PR TITLE
Fix: Use before_install and install sections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,14 @@ php:
   - "7.1"
   - "7.0"
   - "5.6"
-  
+
 jdk:
   - oraclejdk7
-  
-before_script:
+
+before_install:
   - sudo apt-get update
+
+install:
   - sudo apt-get install -y --force-yes --no-install-recommends erlang
   - ./travisci/bin/ci/setup.sh
   - composer install


### PR DESCRIPTION
This PR

* [x] uses the probably more appropriate `before_install` and `install` sections for corresponding steps in `.travis.yml`

💁‍♂️ For reference, see https://docs.travis-ci.com/user/customizing-the-build#The-Build-Lifecycle.