### PR TITLE
Fix: Namespace does not match project structure

### DIFF
--- a/tests/Unit/Network/Observer/ConnectionObserverCollectionTest.php
+++ b/tests/Unit/Network/Observer/ConnectionObserverCollectionTest.php
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Stomp\Tests\Unit\Network\Observer\Heartbeat;
+namespace Stomp\Tests\Unit\Network\Observer;
 
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
This PR

* [x] removes a namespace segment from a test to bring it in line with the project structure
