### PR TITLE
add check for first available header marker #93

### DIFF
--- a/src/Transport/Parser.php
+++ b/src/Transport/Parser.php
@@ -220,15 +220,19 @@ class Parser
      */
     private function detectFrameHead()
     {
-        if (($headerEnd = strpos($this->buffer, self::HEADER_STOP_CR_LF, $this->offset)) !== false) {
-            $this->extractFrameMeta(substr($this->buffer, $this->offset, $headerEnd - $this->offset));
-            $this->offset = $headerEnd + strlen(self::HEADER_STOP_CR_LF);
+        $firstCrLf = strpos($this->buffer, self::HEADER_STOP_CR_LF, $this->offset);
+        $firstLf = strpos($this->buffer, self::HEADER_STOP_LF, $this->offset);
+
+        // we need to use the first available marker, so we need to make sure that cr lf don't overrule lf
+        if ($firstCrLf !== false && ($firstLf === false || $firstLf > $firstCrLf)) {
+            $this->extractFrameMeta(substr($this->buffer, $this->offset, $firstCrLf - $this->offset));
+            $this->offset = $firstCrLf + strlen(self::HEADER_STOP_CR_LF);
             return true;
         }
 
-        if (($headerEnd = strpos($this->buffer, self::HEADER_STOP_LF, $this->offset)) !== false) {
-            $this->extractFrameMeta(substr($this->buffer, $this->offset, $headerEnd - $this->offset));
-            $this->offset = $headerEnd + strlen(self::HEADER_STOP_LF);
+        if ($firstLf !== false) {
+            $this->extractFrameMeta(substr($this->buffer, $this->offset, $firstLf - $this->offset));
+            $this->offset = $firstLf + strlen(self::HEADER_STOP_LF);
             return true;
         }
         return false;
@@ -283,7 +287,7 @@ class Parser
      * Extracts command and headers from given header source.
      *
      * @param $source
-     * @return array
+     * @return void
      */
     private function extractFrameMeta($source)
     {

--- a/tests/Unit/Transport/ParserTest.php
+++ b/tests/Unit/Transport/ParserTest.php
@@ -231,4 +231,32 @@ class ParserTest extends TestCase
         $actual = $this->parser->getFrame();
         $this->assertEquals($expected, $actual);
     }
+
+
+    /**
+     * @see https://github.com/stomp-php/stomp-php/issues/93
+     */
+    public function testParserWhenHeaderStopSequenceWithCarriageReturnIsPartOfBody()
+    {
+        $body = "{ \n\"value1\" : \"hello world\"\n,\n\n  \"value2\" : \"2002-02-01\"\r\n\r\n}";
+        $header = "MESSAGE\n\n";
+        $this->parser->addData($header . $body . "\x00");
+        $this->assertTrue($this->parser->parse());
+        $message = $this->parser->getFrame();
+        $this->assertEquals($body, $message->getBody());
+    }
+
+    /**
+     * @see https://github.com/stomp-php/stomp-php/issues/93
+     */
+    public function testParserWhenHeaderStopSequenceWithoutCarriageReturnIsPartOfBody()
+    {
+        $body = "{ \n\"value1\" : \"hello world\"\n,\n\n  \"value2\" : \"2002-02-01\"\n\n}";
+        $header = "MESSAGE\r\n\r\n";
+        $this->parser->addData($header . $body . "\x00");
+        $this->assertTrue($this->parser->parse());
+        $message = $this->parser->getFrame();
+        $this->assertEquals($body, $message->getBody());
+    }
+
 }


### PR DESCRIPTION
Otherwise carriage return + line feed will be used as marker, even if
frame is escaped with line feed only.

Thanks to @mattford (#93)