### PR TITLE
add check for first available header marker #93

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 sudo: false
+dist: precise
 php:
   - "7.0"
   - "5.6"

--- a/tests/Unit/Stomp/ParserTest.php
+++ b/tests/Unit/Stomp/ParserTest.php
@@ -99,4 +99,32 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $result = $parser->getFrame();
         $this->assertInstanceOf('\Stomp\Frame', $result);
     }
+
+    /**
+     * @see https://github.com/stomp-php/stomp-php/issues/93
+     */
+    public function testParserWhenHeaderStopSequenceWithCarriageReturnIsPartOfBody()
+    {
+        $parser = new Parser();
+        $body = "{ \n\"value1\" : \"hello world\"\n,\n\n  \"value2\" : \"2002-02-01\"\r\n\r\n}";
+        $header = "MESSAGE\n\n";
+        $parser->addData($header . $body . "\x00");
+        $this->assertTrue($parser->parse());
+        $message = $parser->getFrame();
+        $this->assertEquals($body, $message->body);
+    }
+
+    /**
+     * @see https://github.com/stomp-php/stomp-php/issues/93
+     */
+    public function testParserWhenHeaderStopSequenceWithoutCarriageReturnIsPartOfBody()
+    {
+        $parser = new Parser();
+        $body = "{ \n\"value1\" : \"hello world\"\n,\n\n  \"value2\" : \"2002-02-01\"\n\n}";
+        $header = "MESSAGE\r\n\r\n";
+        $parser->addData($header . $body . "\x00");
+        $this->assertTrue($parser->parse());
+        $message = $parser->getFrame();
+        $this->assertEquals($body, $message->body);
+    }
 }


### PR DESCRIPTION
Otherwise carriage return + line feed will be used as marker, even if
frame is escaped with line feed only.

Thanks to @mattford