### PR TITLE
Prevent exception-messages with empty "Host" identifier

### DIFF
--- a/src/Exception/ConnectionException.php
+++ b/src/Exception/ConnectionException.php
@@ -35,7 +35,11 @@ class ConnectionException extends StompException
         $this->connectionInfo = $connection;
 
         $host = ($previous ? $previous->getHostname() : null) ?: $this->getHostname();
-        parent::__construct(sprintf('%s (Host: %s)', $info, $host), 0, $previous);
+        
+        if ($host) {
+            $info = sprintf('%s (Host: %s)', $info, $host);
+        }
+        parent::__construct($info, 0, $previous);
     }
 
 


### PR DESCRIPTION
Prevents Stacktraces/Messages like

```
Uncaught Stomp\Exception\ConnectionException: Connection not acknowledged (Host: ) in 
.../vendor/stomp-php/stomp-php/src/Stomp/Client.php on line 192
```

when no connection-information/host-information is available.