### PR TITLE
add credits section to the readme #98

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # Stomp PHP
 
+[![Build Status](https://travis-ci.org/stomp-php/stomp-php.svg?branch=master)](https://travis-ci.org/stomp-php/stomp-php)
+
 This project is a PHP [Stomp](http://stomp.github.com) Client that besides it implements the Stomp protocol fully,
 brings some ActiveMQ and Apollo specific utils that could make your messaging from PHP easier.
 
-[![Build Status](https://travis-ci.org/stomp-php/stomp-php.svg?branch=master)](https://travis-ci.org/stomp-php/stomp-php)
+## Credits
+
+This library was initially developed by [Dejan Bosanac](https://github.com/dejanb). 
+We would like to thank you for your work and we're happy to continue it.
 
 ## Version choice
 


### PR DESCRIPTION
As we're not longer a direct fork of the original repository at
https://github.com/dejanb/stomp-php we want to make sure that we honor
the developer that created the library.