### PR TITLE
support requeue header on nack

### DIFF
--- a/src/Broker/ActiveMq/ActiveMq.php
+++ b/src/Broker/ActiveMq/ActiveMq.php
@@ -95,8 +95,13 @@ class ActiveMq extends Protocol
     /**
      * @inheritdoc
      */
-    public function getNackFrame(Frame $frame, $transactionId = null)
+    public function getNackFrame(Frame $frame, $transactionId = null, $requeue = null)
     {
+        if ($requeue !== null) {
+            throw new \LogicException(
+                'requeue header not supported by ActiveMQ. Please read ActiveMQ DLQ documentation.'
+            );
+        }
         $nack = $this->createFrame('NACK');
         $nack['transaction'] = $transactionId;
         if ($this->hasVersion(Version::VERSION_1_2)) {

--- a/src/Broker/Apollo/Apollo.php
+++ b/src/Broker/Apollo/Apollo.php
@@ -83,8 +83,11 @@ class Apollo extends Protocol
     /**
      * @inheritdoc
      */
-    public function getNackFrame(Frame $frame, $transactionId = null)
+    public function getNackFrame(Frame $frame, $transactionId = null, $requeue = null)
     {
+        if ($requeue !== null) {
+            throw new \LogicException('requeue header not supported');
+        }
         $nack = $this->createFrame('NACK');
         $nack['transaction'] = $transactionId;
         if ($this->hasVersion(Version::VERSION_1_2)) {

--- a/src/Protocol/Protocol.php
+++ b/src/Protocol/Protocol.php
@@ -99,6 +99,7 @@ class Protocol
      * @param string $ack
      * @param string $selector
      * @return \Stomp\Transport\Frame
+     * @throws StompException;
      */
     public function getSubscribeFrame($destination, $subscriptionId = null, $ack = 'auto', $selector = null)
     {
@@ -212,11 +213,16 @@ class Protocol
      *
      * @param \Stomp\Transport\Frame $frame
      * @param string $transactionId
+     * @param bool $requeue Requeue header
      * @return \Stomp\Transport\Frame
      * @throws StompException
+     * @throws \LogicException
      */
-    public function getNackFrame(Frame $frame, $transactionId = null)
+    public function getNackFrame(Frame $frame, $transactionId = null, $requeue = null)
     {
+        if ($requeue !== null) {
+            throw new \LogicException('requeue header not supported');
+        }
         if ($this->version === Version::VERSION_1_0) {
             throw new StompException('Stomp Version 1.0 has no support for NACK Frames.');
         }

--- a/src/StatefulStomp.php
+++ b/src/StatefulStomp.php
@@ -65,11 +65,12 @@ class StatefulStomp extends StateSetter implements IStateful
      * Not acknowledge consumption of a message from a subscription
      *
      * @param Frame $frame
+     * @param bool $requeue requeue header not supported in all brokers
      * @return void
      */
-    public function nack(Frame $frame)
+    public function nack(Frame $frame, $requeue = null)
     {
-        $this->state->nack($frame);
+        $this->state->nack($frame, $requeue);
     }
 
     /**

--- a/src/States/ConsumerState.php
+++ b/src/States/ConsumerState.php
@@ -78,9 +78,9 @@ class ConsumerState extends StateTemplate
     /**
      * @inheritdoc
      */
-    public function nack(Frame $frame)
+    public function nack(Frame $frame, $requeue = null)
     {
-        $this->getClient()->sendFrame($this->getProtocol()->getNackFrame($frame), false);
+        $this->getClient()->sendFrame($this->getProtocol()->getNackFrame($frame, null, $requeue), false);
     }
 
     /**

--- a/src/States/ConsumerTransactionState.php
+++ b/src/States/ConsumerTransactionState.php
@@ -61,9 +61,9 @@ class ConsumerTransactionState extends ConsumerState
     /**
      * @inheritdoc
      */
-    public function nack(Frame $frame)
+    public function nack(Frame $frame, $requeue = null)
     {
-        $this->getClient()->sendFrame($this->getProtocol()->getNackFrame($frame, $this->transactionId), false);
+        $this->getClient()->sendFrame($this->getProtocol()->getNackFrame($frame, $this->transactionId, $requeue), false);
     }
 
     /**

--- a/src/States/IStateful.php
+++ b/src/States/IStateful.php
@@ -31,9 +31,10 @@ interface IStateful
      * Not acknowledge consumption of a message from a subscription
      *
      * @param Frame $frame
+     * @param bool $requeue Requeue header not supported on all brokers
      * @return void
      */
-    public function nack(Frame $frame);
+    public function nack(Frame $frame, $requeue = null);
 
     /**
      * Send a message.

--- a/src/States/StateTemplate.php
+++ b/src/States/StateTemplate.php
@@ -112,7 +112,7 @@ abstract class StateTemplate extends StateSetter implements IStateful
     /**
      * @inheritdoc
      */
-    public function nack(Frame $frame)
+    public function nack(Frame $frame, $requeue = null)
     {
         throw new InvalidStateException($this, __FUNCTION__);
     }

--- a/tests/Functional/ActiveMq/StatefulTest.php
+++ b/tests/Functional/ActiveMq/StatefulTest.php
@@ -50,4 +50,23 @@ class StatefulTest extends StatefulTestBase
         $this->assertFalse($receiver->read());
         $receiver->unsubscribe();
     }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testNackRequeueException()
+    {
+        $queue = '/queue/tests-ack-nack';
+        $receiver = $this->getStatefulStomp();
+        $producer = $this->getStatefulStomp();
+
+        $receiver->subscribe($queue, null, 'client-individual');
+
+        $producer->send($queue, new Message('message-a', ['persistent' => 'true']));
+        $producer->send($queue, new Message('message-b', ['persistent' => 'true']));
+        $producer->getClient()->disconnect(true);
+
+        $frameA = $receiver->read();
+        $receiver->nack($frameA, true);
+    }
 }


### PR DESCRIPTION
as of rabbitmq 3.4, the NACK command supports the requeue header, necessary for DLX