### PR TITLE
git-export-ignore tests/ and travisci/ folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+travisci/ export-ignore
+tests/ export-ignore


### PR DESCRIPTION
would be great if we wouldn't get the travisci/ and tests/ folder via composer, when installing with --prefer-dist.

with this change composer dont need to install and copy all those files and those will not linger around in production systems etc.

for background see https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/