### PR TITLE
fix broken connection handling

### DIFF
--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -368,7 +368,7 @@ class Connection
         if (!$this->isConnected()) {
             throw new ConnectionException('Not connected to any server.', $this->activeHost);
         }
-        $this->writeData($stompFrame->__toString(), $this->writeTimeout);
+        $this->writeData($stompFrame, $this->writeTimeout);
         $this->observers->sentFrame($stompFrame);
         return true;
     }
@@ -376,12 +376,13 @@ class Connection
     /**
      * Write passed data to the stream, respecting passed timeout.
      *
-     * @param string $data
-     * @param int    $timeout in seconds
+     * @param Frame $stompFrame
+     * @param int $timeout in seconds
      * @throws ConnectionException
      */
-    private function writeData($data, $timeout)
+    private function writeData(Frame $stompFrame, $timeout)
     {
+        $data = $stompFrame->__toString();
         $offset = 0;
         $size = strlen($data);
         $lastByteTime = microtime(true);

--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -160,6 +160,16 @@ class Connection
     }
 
     /**
+     * Returns the connect timeout in seconds.
+     *
+     * @return int
+     */
+    public function getConnectTimeout()
+    {
+        return $this->connectTimeout;
+    }
+
+    /**
      * Returns the collection of observers of this connection.
      *
      * @return ConnectionObserverCollection

--- a/src/Network/Observer/ConnectionObserver.php
+++ b/src/Network/Observer/ConnectionObserver.php
@@ -26,7 +26,7 @@ interface ConnectionObserver
     public function emptyLineReceived();
 
     /**
-     * Indicates that during a read call no frame was received, but an EOL line.
+     * Indicates that during a read call no data was available on the connection.
      *
      * @return void
      */

--- a/tests/Functional/ApolloMq/StatefulTest.php
+++ b/tests/Functional/ApolloMq/StatefulTest.php
@@ -29,7 +29,7 @@ class StatefulTest extends StatefulTestBase
      */
     public function testNackRequeueException()
     {
-        $queue = '/queue/tests-ack-nack';
+        $queue = '/queue/tests-ack-nack-exception';
         $receiver = $this->getStatefulStomp();
         $producer = $this->getStatefulStomp();
 

--- a/tests/Functional/Generic/ConnectionTest.php
+++ b/tests/Functional/Generic/ConnectionTest.php
@@ -41,7 +41,7 @@ class ConnectionTest extends TestCase
             $connection->readFrame();
             $this->fail('Expected a exception!');
         } catch (ConnectionException $exception) {
-            $this->assertContains('Check failed to determine if the socket is readable.', $exception->getMessage());
+            $this->assertContains('Was not possible to read data from stream.', $exception->getMessage());
         }
     }
 

--- a/tests/Unit/Network/ConnectionTest.php
+++ b/tests/Unit/Network/ConnectionTest.php
@@ -170,33 +170,4 @@ class ConnectionTest extends TestCase
         fclose($fakeStreamResource);
         stream_wrapper_unregister('stompFakeStream');
     }
-
-
-    /**
-     * https://github.com/stomp-php/stomp-php/issues/79
-     */
-    public function testHeartBeatsWillNotTriggerFrameDetection()
-    {
-        stream_wrapper_register('stompFakeStream', FakeStream::class);
-
-        $mock = $this->getMockBuilder(Connection::class)
-            ->setMethods(['getConnection'])
-            ->setConstructorArgs(['stompFakeStream://notInUse'])
-            ->getMock();
-        $fakeStreamResource = fopen('stompFakeStream://notInUse', 'rw');
-        $mock->method('getConnection')->willReturn($fakeStreamResource);
-
-        /**
-         * @var $mock Connection
-         */
-        $mock->connect();
-
-        // we setup a stream with heartbeat data only
-        // if the connection is not capable to detect that there is no possible frame data, it will fail
-        FakeStream::$serverSend = "\n\r";
-
-        $this->assertFalse($mock->readFrame());
-        fclose($fakeStreamResource);
-        stream_wrapper_unregister('stompFakeStream');
-    }
 }


### PR DESCRIPTION
This enables non-blocking stream operations and replaces `stream_get_line` with `fread`. As the the previous code failed to recognize that the broker connection was dropped.

This solves #104.