### PR TITLE
Update Parser.php

### DIFF
--- a/src/Transport/Parser.php
+++ b/src/Transport/Parser.php
@@ -339,7 +339,7 @@ class Parser
      */
     private function extractFrameMeta($source)
     {
-        $headers = preg_split("/[\r?\n]+/", $source);
+        $headers = preg_split("/(\r?\n)+/", $source);
 
         $this->command = array_shift($headers);
 


### PR DESCRIPTION
in regex "[....]" denotes a list of chars, hence the pattern "[\r?\n]" is incorrect, as it will split on: '\r', '?' and '\n', while the intention was most likely: split on "\r\n" or "\n", which would have the regex pattern: "(\r?\n)"