### PR TITLE
fix: prevent fwrite be stuck by large streams

### DIFF
--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -387,7 +387,7 @@ class Connection
         $size = strlen($data);
         $lastByteTime = microtime(true);
         do {
-            $written = @fwrite($this->connection, substr($data, $offset), $size - $offset);
+            $written = @fwrite($this->connection, substr($data, $offset), 81920);
 
             if ($written === false) {
                 throw new ConnectionException('Was not possible to write frame!', $this->activeHost);


### PR DESCRIPTION
Under some systems, writing entire large message will cause process block. In this case, fwrite returns 0 and method throws `Was not possible to write frame! Write operation timed out.` exception.

Splitting message into smaller chunks will prevent this behavior.

Warning returned by actual `writeData` method:

```
PHP Warning:  fwrite(): SSL operation failed with code 1. OpenSSL Error messages:
error:1409F07F:SSL routines:SSL3_WRITE_PENDING:bad write retry in /vendor/stomp-php/stomp-php/src/Network/Connection.php on line 390
```

Tested under:

- PHP 5.6.38
- Stomp PHP 4.4.1
- Amazon MQ (Active MQ 5.15.6)