### PR TITLE
fix: reduce bytes length of fwrite to avoid openssl be stuck

### DIFF
--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -387,7 +387,7 @@ class Connection
         $size = strlen($data);
         $lastByteTime = microtime(true);
         do {
-            $written = @fwrite($this->connection, substr($data, $offset), 81920);
+            $written = @fwrite($this->connection, substr($data, $offset), 8192);
 
             if ($written === false) {
                 throw new ConnectionException('Was not possible to write frame!', $this->activeHost);


### PR DESCRIPTION
Related to https://github.com/stomp-php/stomp-php/pull/111 , I'm still getting problems with some streams length in Amazon MQ.

I've tested with several streams lengths and if we set to `8192` like in `@fread` function we will fix the problem.