### PR TITLE
fix connection broken detection (on ssl sockets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,3 +99,4 @@ Thanks to @staabm for all the reviews :)
 - Clients should now use either `ServerAliveObserver` or `HeartbeatEmitter` to verify the state of the connection, otherwise a broken connection might not be detected - especially when the socket is based on ssl.
 - stabilize client heartbeat implementation, added awareness for failing `Connection::sendAlive` calls, now causing `HeartbeatException`
 - added `ServerAliveObserver` in order to simplify detection of dead connections.
+- fixed connection read blocks on os signals until read timeout (thanks to @edefimov, https://github.com/stomp-php/stomp-php/issues/117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,3 +93,9 @@ Thanks to @staabm for all the reviews :)
 ------
 - add configuration for connection read/write may bytes (thanks to @ganeko for this enhancement, https://github.com/stomp-php/stomp-php/pull/113)
 
+4.5.0
+------
+- refined broken connection detection, not longer failing when `fread` returns empty string (thanks to @mlamm for reporting this, https://github.com/stomp-php/stomp-php/issues/115 and https://github.com/stomp-php/stomp-php/issues/114
+- Clients should now use either `ServerAliveObserver` or `HeartbeatEmitter` to verify the state of the connection, otherwise a broken connection might not be detected - especially when the socket is based on ssl.
+- stabilize client heartbeat implementation, added awareness for failing `Connection::sendAlive` calls, now causing `HeartbeatException`
+- added `ServerAliveObserver` in order to simplify detection of dead connections.

--- a/README.md
+++ b/README.md
@@ -17,27 +17,26 @@ We would like to thank you for your work and we're happy to continue it.
 - For running projects with `fusesource/stomp-php@2.x` clients you can use version `2.2.2`.
 - All version newer that `2.x` won't be compatible with `fusesource/stomp-php`. (https://github.com/dejanb/stomp-php.)  
 
-
 ## Installing
 
-The source is PSR-0 compliant. So just download the source and add the Namespace "Stomp" to your autoloader
-configuration with the path pointing to src/.
-
-As an alternate you have the possibility to make use of composer to manage your project dependencies.
-
-Just add
-
-```json
-    "require": {
-        "stomp-php/stomp-php": "4.*"
-    }
+```bash
+composer require stomp-php/stomp-php
 ```
 
-to your project composer.json.
+## Examples
 
-Or simply run `composer require stomp-php/stomp-php` in your project home.
+You find different usage tutorials in our example project https://github.com/stomp-php/stomp-php-examples.
 
-## Replace
+### Connection Probing
+
+It's hard to find out if a socket connection is still working or not, Stomp allows us to use heartbeats to test if client
+and server are ready to serve messages.
+
+You should use `\Stomp\Network\Observer\ServerAliveObserver` or `\Stomp\Network\Observer\HeartbeatEmitter` to receive or 
+send heartbeats. Doing so will ensure that your client will detect a broken connection in time. Please have a look at
+https://github.com/stomp-php/stomp-php-examples for some example code with additonal comments.
+
+## Replace fusesource/stomp-php
 
 If you used `fusesource/stomp-php` before, you can use our `2.x` versions.
 
@@ -46,15 +45,7 @@ If you used `fusesource/stomp-php` before, you can use our `2.x` versions.
         "stomp-php/stomp-php": "2.*"
     }
 ```
-
-## Documentation
-
-See our [wiki](https://github.com/stomp-php/stomp-php/wiki).
-
-## Examples
-
-Have a look at our example project https://github.com/stomp-php/stomp-php-examples.
-
+ 
 ## Contributing
 
 We code in `PSR2`, please use our predefined `pre_commit.sh` hook. 

--- a/src/Client.php
+++ b/src/Client.php
@@ -166,7 +166,10 @@ class Client
    * within an interval - to indicate that the connection is still stable. If client and server agree on a beat and
    * the interval passes without any data activity / beats the connection will be considered as broken and closed.
    *
-   * If you define a heartbeat, you must assure that your application will send data within the interval.
+   * If you want to make sure that the server is still available, you should use the ServerAliveObserver in combination
+   * with an requested server heartbeat interval.
+   *
+   * If you define a heartbeat for client side, you must assure that your application will send data within the interval.
    * You can add \Stomp\Network\Observer\HeartbeatEmitter to your connection in order to send beats automatically.
    *
    * If you don't use HeartbeatEmitter you must either send messages within the interval
@@ -178,12 +181,13 @@ class Client
    * @param int $receive
    *   Number of milliseconds between expected receipt of heartbeats. 0 means
    *   no heartbeats expected. (not yet supported by this client)
+   * @see \Stomp\Network\Observer\ServerAliveObserver
    * @see \Stomp\Network\Observer\HeartbeatEmitter
    * @see \Stomp\Network\Connection::sendAlive()
    */
     public function setHeartbeat($send = 0, $receive = 0)
     {
-      $this->heartbeat = [$send, $receive];
+        $this->heartbeat = [$send, $receive];
     }
 
     /**
@@ -230,13 +234,13 @@ class Client
      * @throws ConnectionException
      * @throws Exception\ErrorFrameException
      */
-    private function getConnectedFrame() {
-        $deadline = microtime(true) + ($this->getConnection()->getConnectTimeout() * 1000000);
+    private function getConnectedFrame()
+    {
+        $deadline = microtime(true) + $this->getConnection()->getConnectTimeout();
         do {
             if ($frame = $this->connection->readFrame()) {
                 return $frame;
             }
-
         } while (microtime(true) <= $deadline);
 
         return null;

--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -560,19 +560,21 @@ class Connection
     private function connectionHasDataToRead($timeoutSec, $timeoutMicros)
     {
         $timeout = microtime(true) + $timeoutSec + ($timeoutMicros ? $timeoutMicros / 1000000 : 0);
-        while (!$this->isDataOnStream()) {
+        while (($hasData = $this->isDataOnStream()) === false) {
             if ($timeout < microtime(true)) {
                 return false;
             }
             time_nanosleep(0, 2500000); // 2.5ms / 0.0025s
         }
-        return true;
+        return $hasData === true;
     }
 
     /**
      * Checks if there is readable data on the stream.
      *
-     * @return bool
+     * Will return true if data is available, false if no data is detected and null if the operation was interrupted.
+     *
+     * @return bool|null
      * @throws ConnectionException
      */
     private function isDataOnStream()
@@ -591,7 +593,7 @@ class Connection
                     $this->activeHost
                 );
             }
-            return false;
+            return null;
         }
 
         return !empty($read);

--- a/src/Network/Observer/AbstractBeats.php
+++ b/src/Network/Observer/AbstractBeats.php
@@ -84,8 +84,8 @@ abstract class AbstractBeats implements ConnectionObserver
     /**
      * Must return the interval (ms) that should be used to detect a delay.
      *
-     * @param integer $maximum
-     * @return integer
+     * @param integer $maximum agreement from client and server in milliseconds
+     * @return float
      */
     abstract protected function calculateInterval($maximum);
 

--- a/src/Network/Observer/AbstractBeats.php
+++ b/src/Network/Observer/AbstractBeats.php
@@ -1,0 +1,255 @@
+<?php
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Network\Observer;
+
+use Stomp\Transport\Frame;
+
+/**
+ * AbstractBeats base for heart beat observer.
+ *
+ * @package Stomp\Network\Observer
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
+ */
+abstract class AbstractBeats implements ConnectionObserver
+{
+    /**
+     * Frame from client that request a connection.
+     */
+    const FRAME_CLIENT_CONNECT = 'CONNECT';
+
+    /**
+     * Frame from server when a connection is established.
+     */
+    const FRAME_SERVER_CONNECTED = 'CONNECTED';
+    /**
+     * The beat interval that the client wants to use.
+     *
+     * @var integer
+     */
+    protected $intervalClient;
+    /**
+     * The beat interval that the server wants to use.
+     *
+     * @var integer
+     */
+    protected $intervalServer;
+    /**
+     * The timestamp that is known as the last time a beat was detected/issued.
+     *
+     * @var float
+     */
+    private $lastbeat;
+
+    /**
+     * The interval (seconds with microseconds as fraction) that will be used to detect a delay.
+     *
+     * @var float
+     */
+    private $intervalUsed;
+
+    /**
+     * Whenever the emitter is configured to send beats.
+     *
+     * @var bool
+     */
+    private $enabled = false;
+
+    /**
+     * A frame with heartbeat details was detected.
+     *
+     * Child class should set client or server interval property.
+     *
+     * @see $intervalClient
+     * @see $intervalServer
+     *
+     * @param Frame $frame
+     * @param array $beats
+     * @return void
+     */
+    abstract protected function onHeartbeatFrame(Frame $frame, array $beats);
+
+    /**
+     * Called whenever the server send data.
+     *
+     * @return void
+     */
+    abstract protected function onServerActivity();
+
+    /**
+     * Must return the interval (ms) that should be used to detect a delay.
+     *
+     * @param integer $maximum
+     * @return integer
+     */
+    abstract protected function calculateInterval($maximum);
+
+    /**
+     * Called whenever a activity is detected that was issued by the client.
+     *
+     * @return void
+     */
+    abstract protected function onClientActivity();
+
+    /**
+     * Something on the connection state could have changed.
+     *
+     * @return void
+     */
+    abstract protected function onPotentialConnectionStateActivity();
+
+    /**
+     * Delay was detected.
+     *
+     * @return void
+     */
+    abstract protected function onDelay();
+
+    /**
+     * Checks if the emitter was enabled.
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Returns if the emitter is in a state that indicates a delay.
+     *
+     * @return bool
+     */
+    public function isDelayed()
+    {
+        if ($this->enabled && $this->lastbeat) {
+            $now = microtime(true);
+            return ($now - $this->lastbeat > $this->intervalUsed);
+        }
+        return false;
+    }
+
+    /**
+     * Returns the calculated interval for beats in seconds (with micro fraction).
+     *
+     * @return null|float
+     */
+    public function getInterval()
+    {
+        return $this->intervalUsed;
+    }
+
+    /**
+     * Check if there is a delay and issue follow up tasks if so.
+     *
+     * @return void
+     */
+    protected function checkDelayed()
+    {
+        if ($this->isDelayed()) {
+            $this->onDelay();
+        }
+    }
+
+    /**
+     * Outgoing activity event.
+     *
+     * @return void
+     */
+    protected function rememberActivity()
+    {
+        $this->lastbeat = microtime(true);
+    }
+
+    /**
+     * Returns the heartbeat header.
+     *
+     * @param Frame $frame
+     * @return array
+     */
+    private function getHeartbeats(Frame $frame)
+    {
+        $beats = $frame['heart-beat'];
+        if ($beats) {
+            return explode(',', $beats, 2);
+        }
+        return [0, 0];
+    }
+
+    /**
+     * Enables the delay detection when preconditions are fulfilled.
+     *
+     * @param Frame $frame
+     * @return void
+     */
+    private function enable(Frame $frame)
+    {
+        $this->onHeartbeatFrame($frame, $this->getHeartbeats($frame));
+        if ($this->intervalServer && $this->intervalClient) {
+            $intervalAgreement = $this->calculateInterval(max($this->intervalClient, $this->intervalServer));
+            $this->intervalUsed = $intervalAgreement / 1000; // milli to micro
+            if ($intervalAgreement) {
+                $this->enabled = true;
+                $this->rememberActivity();
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function receivedFrame(Frame $frame)
+    {
+        if ($this->enabled) {
+            $this->onServerActivity();
+            return;
+        }
+
+        if ($frame->getCommand() === self::FRAME_SERVER_CONNECTED) {
+            $this->enable($frame);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function sentFrame(Frame $frame)
+    {
+        if ($this->enabled) {
+            $this->onClientActivity();
+            return;
+        }
+        if ($frame->getCommand() === self::FRAME_CLIENT_CONNECT) {
+            $this->enable($frame);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function emptyLineReceived()
+    {
+        $this->onServerActivity();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function emptyRead()
+    {
+        $this->onPotentialConnectionStateActivity();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function emptyBuffer()
+    {
+        $this->onServerActivity();
+    }
+}

--- a/src/Network/Observer/ConnectionObserver.php
+++ b/src/Network/Observer/ConnectionObserver.php
@@ -8,7 +8,6 @@
 
 namespace Stomp\Network\Observer;
 
-
 use Stomp\Transport\Frame;
 
 /**
@@ -26,11 +25,18 @@ interface ConnectionObserver
     public function emptyLineReceived();
 
     /**
-     * Indicates that during a read call no data was available on the connection.
+     * Indicates that the connection has no pending data.
      *
      * @return void
      */
     public function emptyBuffer();
+
+    /**
+     * Indicates that the connection tried to read signaled data, but no data was returned.
+     *
+     * @return void
+     */
+    public function emptyRead();
 
     /**
      * Indicates that a frame has been received from the server.

--- a/src/Network/Observer/ConnectionObserverCollection.php
+++ b/src/Network/Observer/ConnectionObserverCollection.php
@@ -8,7 +8,6 @@
 
 namespace Stomp\Network\Observer;
 
-
 use Stomp\Transport\Frame;
 
 /**
@@ -102,7 +101,7 @@ class ConnectionObserverCollection implements ConnectionObserver
     }
 
     /**
-     * Indicates that a read was not performed as the buffer is empty.
+     * Indicates that the connection has no pending data.
      *
      * @return void
      */
@@ -110,6 +109,18 @@ class ConnectionObserverCollection implements ConnectionObserver
     {
         foreach ($this->observers as $item) {
             $item->emptyBuffer();
+        }
+    }
+
+    /**
+     * Indicates that the connection tried to read signaled data, but no data was returned.
+     *
+     * @return void
+     */
+    public function emptyRead()
+    {
+        foreach ($this->observers as $item) {
+            $item->emptyRead();
         }
     }
 }

--- a/src/Network/Observer/Exception/HeartbeatException.php
+++ b/src/Network/Observer/Exception/HeartbeatException.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Network\Observer\Exception;
+
+/**
+ * HeartbeatException indicate that heartbeats where not send or received as expected.
+ *
+ * @package src\Network\Observer\Exception
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
+ */
+class HeartbeatException extends \RuntimeException
+{
+    /**
+     * ClientHeartbeatException constructor.
+     *
+     * @param string $message
+     * @param \Exception|null $previous
+     */
+    public function __construct($message, \Exception $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/Network/Observer/HeartbeatEmitter.php
+++ b/src/Network/Observer/HeartbeatEmitter.php
@@ -116,11 +116,11 @@ class HeartbeatEmitter extends AbstractBeats
      * Must return the interval (ms) that should be used to detect a delay.
      *
      * @param integer $maximum
-     * @return integer
+     * @return float
      */
     protected function calculateInterval($maximum)
     {
-        $intervalUsed = floor($maximum * $this->intervalUsage);
+        $intervalUsed = $maximum * $this->intervalUsage;
         $this->assertReadTimeoutSufficient($intervalUsed);
         return $intervalUsed;
     }
@@ -128,13 +128,13 @@ class HeartbeatEmitter extends AbstractBeats
     /**
      * Verify that the client configured heartbeats don't conflict with the connection read timeout.
      *
-     * @param integer $interval
+     * @param float $interval
      * @return void
      */
     private function assertReadTimeoutSufficient($interval)
     {
         $readTimeout = $this->connection->getReadTimeout();
-        $readTimeoutMs = ($readTimeout[0] * 1000) + floor($readTimeout[1] / 1000);
+        $readTimeoutMs = ($readTimeout[0] * 1000) + ($readTimeout[1] / 1000);
 
         if ($interval < $readTimeoutMs) {
             throw new HeartbeatException(

--- a/src/Network/Observer/HeartbeatEmitter.php
+++ b/src/Network/Observer/HeartbeatEmitter.php
@@ -8,67 +8,34 @@
 
 namespace Stomp\Network\Observer;
 
-
+use Stomp\Exception\ConnectionException;
 use Stomp\Network\Connection;
+use Stomp\Network\Observer\Exception\HeartbeatException;
 use Stomp\Transport\Frame;
 
 /**
- * HeartbeatEmitter a very basic heartbeat emitter.
+ * HeartbeatEmitter a very basic heartbeat emitter that sends beats from client side.
  *
+ * Use this if you can guarantee that your client processes workloads within a given interval. This allows the server to
+ * detect that your client is down when it fails sending heartbeats, your client will also fail with exception when the
+ * server is not longer receiving heartbeats.
+ *
+ * If your client needs a unknown runtime to process Messages you should check ServerAliveObserver.
+ *
+ * @example $client->setHeartbeat(2000, 0); // indicate that we would send beats within a 2 second interval
+ *          $emitter = new HeartbeatEmitter($client->getConnection());
+ *          $client->getConnection()->getObservers()->addObserver($emitter);
+ *
+ * @see ServerAliveObserver
  * @package Stomp\Network\Observer\Heartbeat
  * @author Jens Radtke <swefl.oss@fin-sn.de>
  */
-class HeartbeatEmitter implements ConnectionObserver
+class HeartbeatEmitter extends AbstractBeats
 {
-    /**
-     * Frame from client that request a connection.
-     */
-    const FRAME_CLIENT_CONNECT = 'CONNECT';
-
-    /**
-     * Frame from server when a connection is established.
-     */
-    const FRAME_SERVER_CONNECTED = 'CONNECTED';
-
     /**
      * @var Connection
      */
     private $connection;
-
-    /**
-     * The timestamp that is known as the last time we have send a beat.
-     *
-     * @var float
-     */
-    private $lastbeat;
-
-    /**
-     * The beat interval that the client has offered to the server.
-     *
-     * @var integer
-     */
-    private $intervalClient;
-
-    /**
-     * The beat interval that the server has requested for this connection.
-     *
-     * @var integer
-     */
-    private $intervalServer;
-
-    /**
-     * The interval that will be used to send beats.
-     *
-     * @var float
-     */
-    private $interval;
-
-    /**
-     * Whenever the emitter is configured to send beats.
-     *
-     * @var bool
-     */
-    private $enabled = false;
 
     /**
      * Defines the percentage amount of the calculated interval that will be used without emitting a beat.
@@ -76,6 +43,13 @@ class HeartbeatEmitter implements ConnectionObserver
      * @var float
      */
     private $intervalUsage;
+
+    /**
+     * Enables the pessimistic mode of the emitter, causing alive messages when we receive nothing from the socket.
+     *
+     * @var bool
+     */
+    private $pessimistic = false;
 
     /**
      * Emitter constructor.
@@ -96,41 +70,99 @@ class HeartbeatEmitter implements ConnectionObserver
         $this->connection = $connection;
     }
 
-
     /**
-     * Indicates that during a read call no frame was received, but an EOL line.
+     * Enables the pessimistic mode.
      *
-     * @return void
+     * @param bool $pessimistic
      */
-    public function emptyLineReceived()
+    public function setPessimistic($pessimistic)
     {
-        $this->onPassiveEvent();
+        $this->pessimistic = $pessimistic;
     }
 
     /**
-     * An passive event was fired, all that triggers a connection activity that is not leading to outgoing traffic.
+     * Called whenever the server send data.
      *
      * @return void
      */
-    private function onPassiveEvent()
+    protected function onServerActivity()
     {
-        if ($this->isDelayed()) {
-            $this->sendBeat();
+        $this->checkDelayed();
+    }
+
+    /**
+     * A frame with heartbeat details was detected.
+     *
+     * Class should set client or server interval.
+     *
+     * @param Frame $frame
+     * @param array $beats
+     * @return void
+     */
+    protected function onHeartbeatFrame(Frame $frame, array $beats)
+    {
+        if ($frame->getCommand() === self::FRAME_SERVER_CONNECTED) {
+            $this->intervalServer = $beats[1];
+            if ($this->intervalClient === null) {
+                $this->intervalClient = $this->intervalServer;
+            }
+        } else {
+            $this->intervalClient = $beats[0];
+            $this->rememberActivity();
         }
     }
 
     /**
-     * Check if the emitter is in a state that indicates a delay.
+     * Must return the interval (ms) that should be used to detect a delay.
      *
-     * @return bool
+     * @param integer $maximum
+     * @return integer
      */
-    public function isDelayed()
+    protected function calculateInterval($maximum)
     {
-        if ($this->enabled) {
-            $now = microtime(true);
-            return ($now - $this->lastbeat > $this->interval);
+        $intervalUsed = floor($maximum * $this->intervalUsage);
+        $this->assertReadTimeoutSufficient($intervalUsed);
+        return $intervalUsed;
+    }
+
+    /**
+     * Verify that the client configured heartbeats don't conflict with the connection read timeout.
+     *
+     * @param integer $interval
+     * @return void
+     */
+    private function assertReadTimeoutSufficient($interval)
+    {
+        $readTimeout = $this->connection->getReadTimeout();
+        $readTimeoutMs = ($readTimeout[0] * 1000) + floor($readTimeout[1] / 1000);
+
+        if ($interval < $readTimeoutMs) {
+            throw new HeartbeatException(
+                'Client heartbeat is lower than connection read timeout, causing failing heartbeats.'
+            );
         }
-        return false;
+    }
+
+    /**
+     * Called whenever a activity is detected that was issued by the client.
+     *
+     * @return void
+     */
+    protected function onClientActivity()
+    {
+        $this->rememberActivity();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function onPotentialConnectionStateActivity()
+    {
+        if ($this->pessimistic && $this->isEnabled()) {
+            $this->onDelay();
+        } else {
+            $this->checkDelayed();
+        }
     }
 
     /**
@@ -138,125 +170,13 @@ class HeartbeatEmitter implements ConnectionObserver
      *
      * @return void
      */
-    private function sendBeat()
+    protected function onDelay()
     {
-        $this->connection->sendAlive();
-        $this->rememberBeat();
-    }
-
-    /**
-     * Outgoing activity event.
-     *
-     * @return void
-     */
-    private function rememberBeat()
-    {
-        $this->lastbeat = microtime(true);
-    }
-
-    /**
-     * Indicates that during a read call no frame was received, but an EOL line.
-     *
-     * @return void
-     */
-    public function emptyBuffer()
-    {
-        $this->onPassiveEvent();
-    }
-
-    /**
-     * Indicates that a frame has been received from the server.
-     *
-     * @param Frame $frame that has been received
-     * @return void
-     */
-    public function receivedFrame(Frame $frame)
-    {
-        if ($frame->getCommand() === self::FRAME_SERVER_CONNECTED) {
-            $beats = $this->getHeartbeats($frame);
-            $this->intervalServer = $beats[1];
-            if ($this->intervalServer && ($this->intervalClient || $this->intervalClient === null)) {
-                $this->interval = $this->intervalUsage * (max($this->intervalServer,
-                            $this->intervalClient) / 1000); // milli to micro
-                $this->enabled = true;
-            }
-        } else {
-            $this->onPassiveEvent();
+        try {
+            $this->connection->sendAlive($this->intervalClient / 1000);
+        } catch (ConnectionException $e) {
+            throw new HeartbeatException('Could not send heartbeat to server.', $e);
         }
+        $this->rememberActivity();
     }
-
-    /**
-     * Returns the heartbeat header.
-     *
-     * @param Frame $frame
-     * @return array
-     */
-    private function getHeartbeats(Frame $frame)
-    {
-        $beats = $frame['heart-beat'];
-        if ($beats) {
-            return explode(',', $beats, 2);
-        }
-        return [0, 0];
-    }
-
-    /**
-     * Indicates that a frame has been sent to the server.
-     *
-     * @param Frame $frame
-     * @return void
-     */
-    public function sentFrame(Frame $frame)
-    {
-        if ($this->enabled) {
-            $this->rememberBeat();
-            return;
-        }
-        if ($frame->getCommand() === self::FRAME_CLIENT_CONNECT) {
-            $beats = $this->getHeartbeats($frame);
-            $this->intervalClient = $beats[0];
-            $this->rememberBeat();
-        }
-    }
-
-    /**
-     * Returns the microtime for the moment when the last outgoing beat was detected.
-     *
-     * @return float
-     */
-    public function getLastbeat()
-    {
-        return $this->lastbeat;
-    }
-
-    /**
-     * Returns the calculated interval for outgoing beats in seconds (with micro fraction).
-     *
-     * @return float
-     */
-    public function getInterval()
-    {
-        return $this->interval;
-    }
-
-    /**
-     * Checks if the emitter was enabled.
-     *
-     * @return bool
-     */
-    public function isEnabled()
-    {
-        return $this->enabled;
-    }
-
-    /**
-     * Returns the interval usage.
-     *
-     * @return float
-     */
-    public function getIntervalUsage()
-    {
-        return $this->intervalUsage;
-    }
-
 }

--- a/src/Network/Observer/ServerAliveObserver.php
+++ b/src/Network/Observer/ServerAliveObserver.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Network\Observer;
+
+use Stomp\Network\Observer\Exception\HeartbeatException;
+use Stomp\Transport\Frame;
+
+/**
+ * ServerAliveObserver an observer that checks for signals from server side.
+ *
+ * Use this to ensure that the server your listening to is still alive.
+ *
+ * If you want to signal the server that your client is still available check HeartbeatEmitter.
+ *
+ * @example $client->setHeartbeat(0, 2000); // indicate that we would receive server beats within a 2 second interval
+ *          $client->getConnection()->getObservers()->addObserver(new ServerAliveObserver());
+ *
+ * @see HeartbeatEmitter
+ * @package Stomp\Network\Observer
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
+ */
+class ServerAliveObserver extends AbstractBeats
+{
+    /**
+     * Defines the percentage amount of the calculated interval that will be used without emitting a beat.
+     *
+     * @var float
+     */
+    private $intervalUsage;
+
+    /**
+     * Emitter constructor.
+     *
+     * What is the interval usage?
+     * The usage (percentage) defines the amount of agreed beat interval time,
+     * that is allowed to pass before the observer decides that the server is delayed. (not alive anymore)
+     *
+     * A higher value increases the risk that a dead server is not detected over a given period.
+     * A lower value increases the risk that a server is declared as dead when not.
+     *
+     * @param float $intervalUsage 150% default
+     */
+    public function __construct($intervalUsage = 1.5)
+    {
+        $this->intervalUsage = max(1, $intervalUsage);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function onPotentialConnectionStateActivity()
+    {
+        $this->checkDelayed();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function onServerActivity()
+    {
+        $this->rememberActivity();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function onClientActivity()
+    {
+        // ignored here, as we see failures when the write fails
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function onDelay()
+    {
+        throw new HeartbeatException('The server failed to send expected heartbeats.');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function onHeartbeatFrame(Frame $frame, array $beats)
+    {
+        if ($frame->getCommand() === self::FRAME_CLIENT_CONNECT) {
+            $this->intervalClient = $beats[1];
+        } else {
+            $this->intervalServer = $beats[0];
+            $this->rememberActivity();
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function calculateInterval($maximum)
+    {
+        return $maximum * $this->intervalUsage;
+    }
+}

--- a/tests/Cases/PCNTL/Consumer.php
+++ b/tests/Cases/PCNTL/Consumer.php
@@ -11,7 +11,14 @@ namespace Stomp\Tests\Cases\PCNTL;
 require __DIR__ . '/../../../vendor/autoload.php';
 
 $signalTest = new ConsumerPCNTLTestCase();
-if (!$signalTest->testRegisteredAndTriggeredSignalHandlerWontLeadToConnectionException()) {
+
+$cases = [
+    'signal_handling' => 'testRegisteredAndTriggeredSignalHandlerWontLeadToConnectionException',
+    'signal_handling_wait_callable' => 'testRegisteredWaitCallableWillDirectlyReturnFromRead'
+];
+
+$case = $cases[$argv[1]];
+if (!$signalTest->$case()) {
     echo 'TEST: FAILED', PHP_EOL;
     exit(1);
 } else {

--- a/tests/Cases/PCNTL/StreamSignalTest.php
+++ b/tests/Cases/PCNTL/StreamSignalTest.php
@@ -18,7 +18,21 @@ use PHPUnit\Framework\TestCase;
  */
 class StreamSignalTest extends TestCase
 {
-    public function testSignaledWontBreakStreamSelect()
+    public function signalHandlingProvider()
+    {
+        return [
+            // https://github.com/stomp-php/stomp-php/pull/65
+            'Signal Handler will not throw exception.' => ['signal_handling'],
+            // https://github.com/stomp-php/stomp-php/issues/117
+            'Signal Handler will not wait for read timeout to pass, when wait-callable returns false.' => ['signal_handling_wait_callable']
+        ];
+    }
+
+    /**
+     * @dataProvider signalHandlingProvider
+     * @param string $case
+     */
+    public function testConsumerSignalProcessing($case)
     {
         if (!extension_loaded('pcntl')) {
             $this->markTestSkipped('The pcntl extension is required to run this test case.');
@@ -31,9 +45,10 @@ class StreamSignalTest extends TestCase
 
         $process = proc_open(
             sprintf(
-                'exec %s %s',
+                'exec %s %s %s',
                 PHP_BINARY,
-                realpath(__DIR__ . '/Consumer.php')
+                realpath(__DIR__ . '/Consumer.php'),
+                escapeshellarg($case)
             ),
             $descriptorspec,
             $pipes

--- a/tests/Functional/ActiveMq/ClientTest.php
+++ b/tests/Functional/ActiveMq/ClientTest.php
@@ -439,7 +439,7 @@ class ClientTest extends TestCase
     public function testSendAlive()
     {
         $this->Stomp->connect();
-        $this->assertTrue($this->Stomp->getConnection()->sendAlive());
+        $this->Stomp->getConnection()->sendAlive();
         $this->Stomp->disconnect();
     }
 }

--- a/tests/Unit/Network/Mocks/FakeStream.php
+++ b/tests/Unit/Network/Mocks/FakeStream.php
@@ -42,6 +42,13 @@ class FakeStream
     public static $clientSend = '';
 
     /**
+     * Indicates that send will always fail
+     *
+     * @var bool
+     */
+    public static $sendFails = false;
+
+    /**
      *
      * @see streamWrapper::stream_open()
      *
@@ -78,6 +85,9 @@ class FakeStream
      */
     public function stream_write($data)
     {
+        if (self::$sendFails) {
+            return 0;
+        }
         self::$clientSend .= $data;
         return strlen($data);
     }

--- a/tests/Unit/Network/Observer/AbstractBeatsTest.php
+++ b/tests/Unit/Network/Observer/AbstractBeatsTest.php
@@ -1,0 +1,279 @@
+<?php
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Tests\Unit\Network\Observer;
+
+use PHPUnit\Framework\TestCase;
+use Stomp\Network\Observer\AbstractBeats;
+use Stomp\Transport\Frame;
+
+/**
+ * AbstractBeatsTest
+ *
+ * @package Stomp\Tests\Unit\Network\Observer
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
+ */
+class AbstractBeatsTest extends TestCase
+{
+
+    public function testNotDelayedWhenNotActivated()
+    {
+        $instance = $this->getInstance();
+        $this->assertFalse($instance->isEnabled());
+        $this->assertFalse($instance->isDelayed());
+    }
+
+    public function testCheckDelayTriggersOnDelayIfDelayed()
+    {
+        $instance = $this->getInstance();
+
+        $checkDelayed = new \ReflectionMethod($instance, 'checkDelayed');
+        $checkDelayed->setAccessible(true);
+
+        $instance->expects($this->once())->method('onDelay');
+        $this->injectActivatedWithServerActivityBeatUpdate($instance, 1);
+
+        time_nanosleep(0, 1000000);
+
+        $checkDelayed->invoke($instance);
+        $this->assertTrue($instance->isDelayed());
+    }
+
+    public function testCheckDelayWillNotTriggerOnDelayIfNotDelayed()
+    {
+        $instance = $this->getInstance();
+        $instance->expects($this->never())->method('onDelay');
+        $this->injectActivatedWithServerActivityBeatUpdate($instance, 500);
+
+        $checkDelayed = new \ReflectionMethod($instance, 'checkDelayed');
+        $checkDelayed->setAccessible(true);
+        $checkDelayed->invoke($instance);
+        $this->assertFalse($instance->isDelayed());
+    }
+
+    public function testSendFrameInEnabledStateWillTriggerClientActivity()
+    {
+        $instance = $this->getInstance();
+        $frame = $this->getClientConnectFrame($server = 10, $client = 20);
+
+        $this->assertEnabledOnce($instance, $frame, $server = 10, $client = 20);
+        $instance->expects($this->once())->method('onClientActivity');
+
+        // first call must activate the observer
+        $this->assertFalse($instance->isEnabled());
+        $instance->sentFrame($frame);
+
+        // second call wont start enable process again, but trigger server activity
+        $instance->sentFrame($frame);
+        $this->assertTrue($instance->isEnabled());
+    }
+
+
+    public function testSendFrameInDisabledStateWillProcessConnectFrame()
+    {
+        $instance = $this->getInstance();
+        $instance->expects($this->never())->method('onServerActivity');
+        $instance->expects($this->never())->method('calculateInterval');
+
+        $frame = $this->getClientConnectFrame($server = 5, $client = 10);
+        // connect frame must be forwarded
+        $instance->expects($this->once())->method('onHeartbeatFrame')->with($frame, [10, 5]);
+        $instance->sentFrame($frame);
+
+        $this->assertFalse($instance->isEnabled());
+    }
+
+
+    public function testReceiveFrameInEnabledStateWillTriggerServerActivity()
+    {
+        $instance = $this->getInstance();
+        $frame = $this->getServerConnectedFrame($server = 10, $client = 20);
+
+        $this->assertEnabledOnce($instance, $frame, $server = 10, $client = 20);
+        $instance->expects($this->once())->method('onServerActivity');
+
+        // first call must activate the observer
+        $this->assertFalse($instance->isEnabled());
+        $instance->receivedFrame($frame);
+
+        // second call wont start enable process again, but trigger server activity
+        $instance->receivedFrame($frame);
+        $this->assertTrue($instance->isEnabled());
+    }
+
+    public function testReceiveFrameInDisabledStateWillProcessConnectFrame()
+    {
+        $instance = $this->getInstance();
+        $instance->expects($this->never())->method('onServerActivity');
+        $instance->expects($this->never())->method('calculateInterval');
+
+        // connected frame must be forwarded
+        $frame = $this->getServerConnectedFrame($server = 10, $client = 20);
+        $instance->expects($this->once())->method('onHeartbeatFrame')->with($frame, [10, 20]);
+        $instance->receivedFrame($frame);
+
+        $this->assertFalse($instance->isEnabled());
+    }
+
+    public function testHeartbeatConfigReceivesZeroValuesForMissingHeartbeatHeaders()
+    {
+        $instance = $this->getInstance();
+
+        // connected frame must be forwarded
+        $frame = new Frame(AbstractBeats::FRAME_SERVER_CONNECTED);
+        $instance->expects($this->once())->method('onHeartbeatFrame')->with($frame, [0, 0]);
+        $instance->receivedFrame($frame);
+    }
+
+    public function testGetIntervalReturnsResultFromCalculateIntervalInMicroSeconds()
+    {
+        $instance = $this->getInstance();
+        $this->injectActivatedWithServerActivityBeatUpdate($instance, 1);
+        $this->assertEquals(0.001, $instance->getInterval());
+    }
+
+    public function testEmptyLineReceivedWillTriggerServerActivity()
+    {
+        $instance = $this->getInstance();
+        $instance->expects($this->once())->method('onServerActivity');
+        $instance->emptyLineReceived();
+    }
+
+    public function testEmptyReadWillTriggerPotentialConnectionStateActivity()
+    {
+        $instance = $this->getInstance();
+        $instance->expects($this->once())->method('onPotentialConnectionStateActivity');
+        $instance->emptyRead();
+    }
+
+    public function testEmptyBufferWillTriggerServerActivity()
+    {
+        $instance = $this->getInstance();
+        $instance->expects($this->once())->method('onServerActivity');
+        $instance->emptyBuffer();
+    }
+
+    /**
+     * Injects a function that will update the last detected beat whenever a server signal is received.
+     *
+     * @noinspection PhpDocMissingThrowsInspection
+     * @param \PHPUnit_Framework_MockObject_MockObject|AbstractBeats $instance
+     * @param $interval
+     */
+    private function injectActivatedWithServerActivityBeatUpdate(
+        \PHPUnit_Framework_MockObject_MockObject $instance,
+        $interval
+    ) {
+        $frame = $this->getServerConnectedFrame($interval, $interval);
+        $this->assertEnabledOnce($instance, $frame, $interval, $interval);
+        $instance->receivedFrame($frame);
+        $remember = new \ReflectionMethod($instance, 'rememberActivity');
+        $remember->setAccessible(true);
+        $instance->expects($this->any())
+            ->method('onServerActivity')
+            ->willReturnCallback(
+                function () use ($instance, $remember) {
+                    $remember->invoke($instance);
+                }
+            );
+    }
+
+    /**
+     * Assert that the instance will be enabled when a frame with heartbeat details is detected.
+     *
+     * @param \PHPUnit_Framework_MockObject_MockObject|AbstractBeats $instance
+     * @param Frame $frame
+     * @param integer $intervalServer
+     * @param integer $intervalClient
+     */
+    private function assertEnabledOnce(
+        \PHPUnit_Framework_MockObject_MockObject $instance,
+        Frame $frame,
+        $intervalServer,
+        $intervalClient
+    ) {
+        $instance->expects($this->once())
+            ->method('onHeartbeatFrame')
+            ->with($frame)
+            ->willReturnCallback(
+                function () use ($instance, $intervalServer, $intervalClient) {
+                    $this->injectClientInterval($instance, $intervalServer);
+                    $this->injectServerInterval($instance, $intervalClient);
+                }
+            );
+        $instance->expects($this->once())
+            ->method('calculateInterval')
+            ->willReturn(max($intervalClient, $intervalClient));
+    }
+
+    /**
+     * Sets the interval property for client side.
+     *
+     * @noinspection PhpDocMissingThrowsInspection
+     * @param AbstractBeats $instance
+     * @param $interval
+     */
+    private function injectClientInterval(AbstractBeats $instance, $interval)
+    {
+        $property = new \ReflectionProperty($instance, 'intervalClient');
+        $property->setAccessible(true);
+        $property->setValue($instance, $interval);
+    }
+
+    /**
+     * Sets the interval property for server side.
+     *
+     * @noinspection PhpDocMissingThrowsInspection
+     * @param AbstractBeats $instance
+     * @param $interval
+     */
+    private function injectServerInterval(AbstractBeats $instance, $interval)
+    {
+        $property = new \ReflectionProperty($instance, 'intervalServer');
+        $property->setAccessible(true);
+        $property->setValue($instance, $interval);
+    }
+
+    /**
+     * Generates a beat instance.
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|AbstractBeats
+     */
+    private function getInstance()
+    {
+        return $this->getMockForAbstractClass(AbstractBeats::class);
+    }
+
+    /**
+     * Returns a connected frame from server side.
+     *
+     * @param integer $server interval
+     * @param integer $client interval
+     * @return Frame
+     */
+    private function getServerConnectedFrame($server, $client)
+    {
+        $frame = new Frame(AbstractBeats::FRAME_SERVER_CONNECTED);
+        $frame['heart-beat'] = sprintf('%d,%d', $server, $client);
+        return $frame;
+    }
+
+    /**
+     * Returns a connect frame from client side.
+     *
+     * @param integer $server interval
+     * @param integer $client interval
+     * @return Frame
+     */
+    private function getClientConnectFrame($server, $client)
+    {
+        $frame = new Frame(AbstractBeats::FRAME_CLIENT_CONNECT);
+        $frame['heart-beat'] = sprintf('%d,%d', $client, $server);
+        return $frame;
+    }
+}

--- a/tests/Unit/Network/Observer/ConnectionObserverCollectionTest.php
+++ b/tests/Unit/Network/Observer/ConnectionObserverCollectionTest.php
@@ -8,7 +8,6 @@
 
 namespace Stomp\Tests\Unit\Network\Observer;
 
-
 use PHPUnit\Framework\TestCase;
 use Stomp\Network\Observer\ConnectionObserver;
 use Stomp\Network\Observer\ConnectionObserverCollection;
@@ -38,15 +37,16 @@ class ConnectionObserverCollectionTest extends TestCase
         $frameA = new Message('message-a');
         $frameB = new Message('message-b');
         $observerA = $this->getMockBuilder(ConnectionObserver::class)
-            ->setMethods(['sentFrame', 'emptyLineReceived', 'emptyBuffer', 'receivedFrame'])
+            ->setMethods(['sentFrame', 'emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'emptyRead'])
             ->getMock();
         $observerA->expects($this->exactly(1))->method('sentFrame')->with($frameA);
         $observerA->expects($this->exactly(1))->method('emptyLineReceived');
         $observerA->expects($this->exactly(1))->method('emptyBuffer');
+        $observerA->expects($this->exactly(1))->method('emptyRead');
         $observerA->expects($this->exactly(1))->method('receivedFrame')->with($frameB);
 
         $observerB = $this->getMockBuilder(ConnectionObserver::class)
-            ->setMethods(['sentFrame', 'emptyLineReceived', 'emptyBuffer', 'receivedFrame'])
+            ->setMethods(['sentFrame', 'emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'emptyRead'])
             ->getMock();
         $observerB->expects($this->exactly(1))->method('sentFrame')->with($frameA);
         $observerB->expects($this->exactly(1))->method('emptyLineReceived');
@@ -59,6 +59,7 @@ class ConnectionObserverCollectionTest extends TestCase
         $this->instance->receivedFrame($frameB);
         $this->instance->sentFrame($frameA);
         $this->instance->emptyBuffer();
+        $this->instance->emptyRead();
         $this->instance->emptyLineReceived();
     }
 

--- a/tests/Unit/Network/Observer/ServerAliveObserverTest.php
+++ b/tests/Unit/Network/Observer/ServerAliveObserverTest.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\Tests\Unit\Network\Observer;
+
+use PHPUnit\Framework\TestCase;
+use Stomp\Network\Observer\AbstractBeats;
+use Stomp\Network\Observer\ServerAliveObserver;
+use Stomp\Transport\Frame;
+
+/**
+ * ServerAliveObserverTest
+ *
+ * @package Stomp\Tests\Unit\Network\Observer
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
+ */
+class ServerAliveObserverTest extends TestCase
+{
+
+    public function testHeartBeatFrameMapping()
+    {
+        $instance = new ServerAliveObserver();
+        $method = new \ReflectionMethod($instance, 'onHeartbeatFrame');
+        $method->setAccessible(true);
+
+        $method->invoke($instance, new Frame(AbstractBeats::FRAME_CLIENT_CONNECT), [10, 20]);
+        $clientProperty = new \ReflectionProperty($instance, 'intervalClient');
+        $clientProperty->setAccessible(true);
+        self::assertEquals(20, $clientProperty->getValue($instance));
+
+        $method->invoke($instance, new Frame(AbstractBeats::FRAME_SERVER_CONNECTED), [30, 40]);
+        $serverProperty = new \ReflectionProperty($instance, 'intervalServer');
+        $serverProperty->setAccessible(true);
+        self::assertEquals(30, $serverProperty->getValue($instance));
+    }
+
+    public function testCalculateInterval()
+    {
+        $instance = new ServerAliveObserver(5);
+        $method = new \ReflectionMethod($instance, 'calculateInterval');
+        $method->setAccessible(true);
+        self::assertEquals(20, $method->invoke($instance, 4));
+    }
+
+    /**
+     * @expectedExceptionMessage The server failed to send expected heartbeats.
+     * @expectedException \Stomp\Network\Observer\Exception\HeartbeatException
+     */
+    public function testOnDelayThrowsException()
+    {
+        $instance = new ServerAliveObserver();
+        $method = new \ReflectionMethod($instance, 'onDelay');
+        $method->setAccessible(true);
+        $method->invoke($instance);
+    }
+
+    /**
+     * Check that the given activity indicator raises a certain follow up task or not.
+     *
+     * @param string $activityMethod
+     * @param string|null $observerMethod
+     * @throws \ReflectionException
+     *
+     * @dataProvider observerMappingProvider
+     */
+    public function testObserverMapping($activityMethod, $observerMethod = null)
+    {
+        $methods = ['rememberActivity', 'checkDelayed'];
+        $instance = $this->getMockBuilder(ServerAliveObserver::class)
+            ->setMethods($methods)
+            ->getMock();
+        foreach ($methods as $method) {
+            $instance->expects(($observerMethod === $method) ? $this->once() : $this->never())
+                ->method($method);
+        }
+        $method = new \ReflectionMethod($instance, $activityMethod);
+        $method->setAccessible(true);
+        $method->invoke($instance);
+    }
+
+    public function observerMappingProvider()
+    {
+        return [
+            'Connection State Changes' => [
+                'onPotentialConnectionStateActivity',
+                'checkDelayed'
+            ],
+            'Server Activity' => [
+                'onServerActivity',
+                'rememberActivity'
+            ],
+            'Client Activity' => [
+                'onClientActivity'
+            ]
+        ];
+    }
+}

--- a/tests/Unit/Transport/ParserTest.php
+++ b/tests/Unit/Transport/ParserTest.php
@@ -277,12 +277,13 @@ class ParserTest extends TestCase
     public function testParserTriggersObserversHeartBeatAfterFrame()
     {
         $observer = $this->getMockBuilder(ConnectionObserver::class)
-            ->setMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame'])
+            ->setMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame', 'emptyRead'])
             ->getMock();
         $observer->expects($this->once())->method('emptyLineReceived');
         $observer->expects($this->once())->method('receivedFrame');
         $observer->expects($this->never())->method('sentFrame');
         $observer->expects($this->never())->method('emptyBuffer');
+        $observer->expects($this->never())->method('emptyRead');
         $this->parser->setObserver($observer);
 
         $data = "RECEIPT\nreceipt-id:813b64a2909519e0a77e1025be67a648\n\n\x00\n\n";
@@ -294,12 +295,13 @@ class ParserTest extends TestCase
     public function testParserTriggersObserversOnSingleHeartBeat()
     {
         $observer = $this->getMockBuilder(ConnectionObserver::class)
-            ->setMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame'])
+            ->setMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame', 'emptyRead'])
             ->getMock();
         $observer->expects($this->once())->method('emptyLineReceived');
         $observer->expects($this->never())->method('receivedFrame');
         $observer->expects($this->never())->method('sentFrame');
         $observer->expects($this->never())->method('emptyBuffer');
+        $observer->expects($this->never())->method('emptyRead');
         $this->parser->setObserver($observer);
 
         $this->parser->addData("\n");
@@ -309,12 +311,13 @@ class ParserTest extends TestCase
     public function testParserTriggersObserversOnMultipleHeartBeatOnlyOnce()
     {
         $observer = $this->getMockBuilder(ConnectionObserver::class)
-            ->setMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame'])
+            ->setMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame', 'emptyRead'])
             ->getMock();
         $observer->expects($this->once())->method('emptyLineReceived');
         $observer->expects($this->never())->method('receivedFrame');
         $observer->expects($this->never())->method('sentFrame');
         $observer->expects($this->never())->method('emptyBuffer');
+        $observer->expects($this->never())->method('emptyRead');
         $this->parser->setObserver($observer);
 
         $this->parser->addData("\n\n");


### PR DESCRIPTION
The previous checks within `Connection::readFrame` often failed for ssl
connections on AWS. This was caused by the fact that `stream_select` will
fail to reliable determine if there is already processable data on the
encrypted stream. It returns true while the stream is not yet ready to
be consumed, which causes `fread` to return an empty string, which was
considered as failure before.
Related to https://github.com/stomp-php/stomp-php/issues/115

BC: As `fread` also returns an empty string for sockets that are broken,
we now need to make use of heartbeats to determine the status of the
connection. `HeartbeatEmitter` was adapted, so that a failing alive
notification now also causes an exception.
In addition `ServerAliveObserver` was added, which simplifies the usage
of server side triggered heartbeats to determine if the connection is
still stable.