### PR TITLE
Break socket select loop when receives signal during sleeping

### DIFF
--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -597,8 +597,13 @@ class Connection
                     return false;
                 }
             }
-            time_nanosleep(0, 2500000); // 2.5ms / 0.0025s
+
+            $slept = time_nanosleep(0, 2500000); // 2.5ms / 0.0025s
+            if (\is_array($slept)) {
+                return false;
+            }
         }
+
         return $hasData === true;
     }
 


### PR DESCRIPTION
This PR fixes the case when application receives OS signal inside `time_nanosleep` while waiting data on a socket. The signal in this case should interrupt data checking loop.