### PR TITLE
[ISSUE-129] Support ?randomize=false on failover:// broker URIs.

### DIFF
--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -366,10 +366,23 @@ class Connection
     protected function getHostList()
     {
         $hosts = array_values($this->hosts);
-        if ($this->params['randomize']) {
+        if ($this->shouldRandomizeHosts()) {
             shuffle($hosts);
         }
         return $hosts;
+    }
+
+    /**
+     * Returns whether the broker host list should be shuffled in random order.
+     *
+     * This applies when specifying multiple hosts using a failover:// protocol in the URI.
+     *
+     * @return bool
+     *   Whether the broker hosts should be shuffled in random order.
+     */
+    protected function shouldRandomizeHosts()
+    {
+        return filter_var($this->params['randomize'], FILTER_VALIDATE_BOOLEAN);
     }
 
     /**

--- a/tests/Unit/Network/ConnectionTest.php
+++ b/tests/Unit/Network/ConnectionTest.php
@@ -38,6 +38,38 @@ class ConnectionTest extends TestCase
         $this->assertEquals('host2', $list[1]['host'], 'List is not in expected order.');
     }
 
+    /**
+     * Data provider for testBrokerUriShouldRandomizeHosts().
+     */
+    public function testBrokerUriShouldRandomizeHostsProvider()
+    {
+        return [
+            'non-failover URI' => ['tcp://host1:61614', false],
+            'no randomize param' => ['failover://(tcp://host1:61614,ssl://host2:61612)', false],
+            'randomize=true param' => ['failover://(tcp://host1:61614,ssl://host2:61612)?randomize=true', true],
+            'randomize=false param' => ['failover://(tcp://host1:61614,ssl://host2:61612)?randomize=false', false]
+        ];
+    }
+
+    /**
+     * Tests Connection::shouldRandomizeHosts().
+     *
+     * @param string $uri
+     *   The broker URI string.
+     * @param bool $expected
+     *   The expected result, TRUE/FALSE.
+     *
+     * @dataProvider testBrokerUriShouldRandomizeHostsProvider
+     */
+    public function testBrokerUriShouldRandomizeHosts($uri, $expected)
+    {
+        $connection = new Connection($uri);
+        $shouldRandomizeHosts = new ReflectionMethod($connection, 'shouldRandomizeHosts');
+        $shouldRandomizeHosts->setAccessible(true);
+
+        $this->assertEquals($expected, $shouldRandomizeHosts->invoke($connection));
+    }
+
     public function testBrokerUriParseSimple()
     {
         $connection = new Connection('tcp://host1');


### PR DESCRIPTION
Fixes https://github.com/stomp-php/stomp-php/issues/129