### PR TITLE
Fix: fetching of large messages sometimes fails

### DIFF
--- a/run_phpunit.sh
+++ b/run_phpunit.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./vendor/bin/phpunit --no-configuration tests/Unit/Stomp
+./vendor/bin/phpunit --no-configuration tests/Unit

--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -546,7 +546,7 @@ class Connection
             if ($frame = $this->parser->nextFrame()) {
                 return $this->onFrame($frame);
             }
-        } while ($this->isDataOnStream());
+        } while ($this->hasDataToRead());
 
         return false;
     }
@@ -684,7 +684,7 @@ class Connection
             $this->writeData(self::ALIVE, $timeout);
         }
     }
-    
+
     /**
      * Immediately releases all allocated resources when the connection object gets destroyed.
      *


### PR DESCRIPTION
Hi there,

I encountered a problem while fetching large messages (>10MB each) from ActiveMQ Queue on remote server.

The problem was that `Connection::isDataOnStream` used to return `false`, while the message wasn't fully fetched. I suppose that happened because next chunk of data from remote server wasn't yet available in the connection socket.

The change in `Connection::readFrame`'s while from `isDataOnStream() ` to `hasDataToRead()` allows code to wait for the data to arrive over the network, based on`Connection::readTimeout` variable.

After that change, my communication became stable.

My second change fixes `run_phpunit.sh` script. After the change it is possible to execute unit tests using this script.

All the best,
Szymon