### PR TITLE
bugfix #141 ack on stomp 1.2 was using id header instead of ack header

### DIFF
--- a/src/Broker/OpenMq/OpenMq.php
+++ b/src/Broker/OpenMq/OpenMq.php
@@ -29,7 +29,11 @@ class OpenMq extends Protocol
         $ack = $this->createFrame('ACK');
         $ack['transaction'] = $transactionId;
         if ($this->hasVersion(Version::VERSION_1_2)) {
-            $ack['id'] = $frame->getMessageId();
+            if (isset($frame['ack'])) {
+                $ack['id'] = $frame['ack'];
+            } else {
+                $ack['id'] = $frame->getMessageId();
+            }
         } else {
             $ack['message-id'] = $frame->getMessageId();
         }

--- a/src/Protocol/Protocol.php
+++ b/src/Protocol/Protocol.php
@@ -203,7 +203,11 @@ class Protocol
         $ack = $this->createFrame('ACK');
         $ack['transaction'] = $transactionId;
         if ($this->hasVersion(Version::VERSION_1_2)) {
-            $ack['id'] = $frame->getMessageId();
+            if (isset($frame['ack'])) {
+                $ack['id'] = $frame['ack'];
+            } else {
+                $ack['id'] = $frame->getMessageId();
+            }
         } else {
             $ack['message-id'] = $frame->getMessageId();
             if ($this->hasVersion(Version::VERSION_1_1)) {

--- a/tests/Functional/Artemis/StatefulTest.php
+++ b/tests/Functional/Artemis/StatefulTest.php
@@ -56,7 +56,7 @@ class StatefulTest extends StatefulTestBase
      */
     public function testNackRequeueException()
     {
-        $queue = 'queue/tests-ack-nack';
+        $queue = 'queue/tests-ack-nack-add-again';
         $receiver = $this->getStatefulStomp();
         $producer = $this->getStatefulStomp();
 

--- a/tests/Unit/Protocol/ProtocolTestCase.php
+++ b/tests/Unit/Protocol/ProtocolTestCase.php
@@ -75,13 +75,26 @@ abstract class ProtocolTestCase extends TestCase
         $this->assertEquals('my-transaction', $actual['transaction']);
     }
 
-    public function testAckVersionTwo()
+    public function testAckVersionTwoBC()
     {
         $instance = $this->getProtocol(Version::VERSION_1_2);
 
         $actual = $instance->getAckFrame(new Frame(null, ['message-id' => 'id-value']), 'my-transaction');
         $this->assertIsAckFrame($actual);
         $this->assertEquals('id-value', $actual['id']);
+        $this->assertEquals('my-transaction', $actual['transaction']);
+    }
+
+    public function testAckVersionTwo()
+    {
+        $instance = $this->getProtocol(Version::VERSION_1_2);
+
+        $actual = $instance->getAckFrame(
+            new Frame(null, ['message-id' => 'id-value', 'ack' => 'ack-id-value']),
+            'my-transaction'
+        );
+        $this->assertIsAckFrame($actual);
+        $this->assertEquals('ack-id-value', $actual['id']);
         $this->assertEquals('my-transaction', $actual['transaction']);
     }
 


### PR DESCRIPTION
fixes https://github.com/stomp-php/stomp-php/issues/141