### PR TITLE
bugfix #135 handle draining messages after unsubscribe

### DIFF
--- a/src/States/ConsumerState.php
+++ b/src/States/ConsumerState.php
@@ -43,12 +43,6 @@ class ConsumerState extends StateTemplate
     protected $destination;
 
     /**
-     * SubscriptionId
-     * @var int
-     */
-    protected $subId;
-
-    /**
      * @var SubscriptionList
      */
     protected $subscriptions;
@@ -124,9 +118,15 @@ class ConsumerState extends StateTemplate
     public function unsubscribe($subscriptionId = null)
     {
         if ($this->endSubscription($subscriptionId)) {
-            $this->setState(
-                new ProducerState($this->getClient(), $this->getBase())
-            );
+            if ($this->getClient()->isBufferEmpty()) {
+                $this->setState(
+                    new ProducerState($this->getClient(), $this->getBase())
+                );
+            } else {
+                $this->setState(
+                    new DrainingConsumerState($this->getClient(), $this->getBase())
+                );
+            }
         }
     }
 

--- a/src/States/ConsumerTransactionState.php
+++ b/src/States/ConsumerTransactionState.php
@@ -75,10 +75,17 @@ class ConsumerTransactionState extends ConsumerState
     public function unsubscribe($subscriptionId = null)
     {
         if ($this->endSubscription($subscriptionId)) {
-            $this->setState(
-                new ProducerTransactionState($this->getClient(), $this->getBase()),
-                ['transactionId' => $this->transactionId]
-            );
+            if ($this->getClient()->isBufferEmpty()) {
+                $this->setState(
+                    new ProducerTransactionState($this->getClient(), $this->getBase()),
+                    ['transactionId' => $this->transactionId]
+                );
+            } else {
+                $this->setState(
+                    new DrainingTransactionConsumerState($this->getClient(), $this->getBase()),
+                    ['transactionId' => $this->transactionId]
+                );
+            }
         }
     }
 

--- a/src/States/DrainingConsumerState.php
+++ b/src/States/DrainingConsumerState.php
@@ -1,0 +1,86 @@
+<?php
+
+
+namespace Stomp\States;
+
+use Stomp\States\Exception\DrainingMessageException;
+use Stomp\Transport\Frame;
+use Stomp\Transport\Message;
+
+class DrainingConsumerState extends StateTemplate
+{
+
+    /**
+     * Activates the current state, after it has been applied on base.
+     *
+     * @param array $options
+     * @return mixed
+     */
+    protected function init(array $options = [])
+    {
+    }
+
+    /**
+     * Returns the options needed in current state.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function ack(Frame $frame)
+    {
+        $this->getClient()->sendFrame($this->getProtocol()->getAckFrame($frame), false);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function nack(Frame $frame, $requeue = null)
+    {
+        $this->getClient()->sendFrame($this->getProtocol()->getNackFrame($frame, null, $requeue), false);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function send($destination, Message $message)
+    {
+        return $this->getClient()->send($destination, $message);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function read()
+    {
+        if ($frame = $this->getClient()->readFrame()) {
+            return $frame;
+        }
+        $this->setState(
+            new ProducerState($this->getClient(), $this->getBase())
+        );
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function begin()
+    {
+        throw new DrainingMessageException($this->getClient(), $this, __FUNCTION__);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function subscribe($destination, $selector, $ack, array $header = [])
+    {
+        throw new DrainingMessageException($this->getClient(), $this, __FUNCTION__);
+    }
+}

--- a/src/States/DrainingTransactionConsumerState.php
+++ b/src/States/DrainingTransactionConsumerState.php
@@ -1,0 +1,71 @@
+<?php
+
+
+namespace Stomp\States;
+
+use Stomp\States\Exception\DrainingMessageException;
+use Stomp\Transport\Frame;
+
+class DrainingTransactionConsumerState extends ConsumerState
+{
+    use TransactionsTrait;
+
+    /**
+     * @inheritdoc
+     */
+    protected function init(array $options = [])
+    {
+        $this->initTransaction($options);
+        return parent::init($options);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function ack(Frame $frame)
+    {
+        $this->getClient()->sendFrame($this->getProtocol()->getAckFrame($frame, $this->transactionId), false);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function nack(Frame $frame, $requeue = null)
+    {
+        $this->getClient()->sendFrame(
+            $this->getProtocol()->getNackFrame($frame, $this->transactionId, $requeue),
+            false
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function read()
+    {
+        if ($frame = $this->getClient()->readFrame()) {
+            return $frame;
+        }
+        $this->setState(
+            new ProducerTransactionState($this->getClient(), $this->getBase()),
+            ['transactionId' => $this->transactionId]
+        );
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function commit()
+    {
+        throw new DrainingMessageException($this->getClient(), $this, __FUNCTION__);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function abort()
+    {
+        throw new DrainingMessageException($this->getClient(), $this, __FUNCTION__);
+    }
+}

--- a/src/States/Exception/DrainingMessageException.php
+++ b/src/States/Exception/DrainingMessageException.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * This file is part of the Stomp package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stomp\States\Exception;
+
+use Stomp\Client;
+use Stomp\States\IStateful;
+
+/**
+ * DrainingMessageException indicates that an call to an operation is not respecting draining messages.
+ *
+ * @package Stomp\States\Exception
+ * @author Jens Radtke <swefl.oss@fin-sn.de>
+ */
+class DrainingMessageException extends InvalidStateException
+{
+    /** @var Client */
+    private $client;
+
+    public function __construct(Client $client, IStateful $state, $method)
+    {
+        $this->client = $client;
+        parent::__construct(
+            $state,
+            $method,
+            'Please make sure that there is no draining message left. Call read until it returns false.'
+        );
+    }
+
+    /**
+     * @return Client
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
+}

--- a/src/States/Exception/InvalidStateException.php
+++ b/src/States/Exception/InvalidStateException.php
@@ -20,14 +20,43 @@ use Stomp\States\IStateful;
 class InvalidStateException extends StompException
 {
 
+    /** @var IStateful */
+    private $state;
+
+    /** @var string|null */
+    private $hint;
+
     /**
      * InvalidStateException constructor.
      *
      * @param IStateful $state
      * @param string $method
+     * @param string|null $hint
      */
-    public function __construct(IStateful $state, $method)
+    public function __construct(IStateful $state, $method, $hint = null)
     {
-        parent::__construct(sprintf('"%s" is not allowed in "%s".', $method, get_class($state)));
+        $this->state = $state;
+        $this->hint = $hint;
+        if ($hint !== null) {
+            parent::__construct(sprintf('"%s" is not allowed in "%s". %s', $method, get_class($state), $hint));
+        } else {
+            parent::__construct(sprintf('"%s" is not allowed in "%s".', $method, get_class($state)));
+        }
+    }
+
+    /**
+     * @return IStateful
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getHint()
+    {
+        return $this->hint;
     }
 }

--- a/src/Transport/Parser.php
+++ b/src/Transport/Parser.php
@@ -389,4 +389,14 @@ class Parser
         $this->buffer = '';
         return $currentBuffer;
     }
+
+    /**
+     * Checks if there is nothing left to parse.
+     *
+     * @return bool
+     */
+    public function isBufferEmpty()
+    {
+        return $this->bufferSize === 0 || $this->offset === $this->bufferSize;
+    }
 }


### PR DESCRIPTION
When clients use `auto ack` and `unsubscribe` it's possible that messages are considered as processed, while they have never been forwarded by `read`.
In order to avoid accidental message los a DrainingConsumer state was added, that comes together with the `DrainingMessageException`.
Access to `Parser` internal buffer has been simplified, by adding `isBufferEmpty`.
Same applies for `Client` here `isBufferEmpty` and `flushBufferedFrames` were added.