### PR TITLE
Fix emptyBuffer() handling

### DIFF
--- a/src/Network/Observer/AbstractBeats.php
+++ b/src/Network/Observer/AbstractBeats.php
@@ -250,6 +250,6 @@ abstract class AbstractBeats implements ConnectionObserver
      */
     public function emptyBuffer()
     {
-        $this->onServerActivity();
+        $this->onPotentialConnectionStateActivity();
     }
 }

--- a/tests/Unit/Network/Observer/AbstractBeatsTest.php
+++ b/tests/Unit/Network/Observer/AbstractBeatsTest.php
@@ -150,10 +150,10 @@ class AbstractBeatsTest extends TestCase
         $instance->emptyRead();
     }
 
-    public function testEmptyBufferWillTriggerServerActivity()
+    public function testEmptyBufferWillTriggerPotentialConnectionStateActivity()
     {
         $instance = $this->getInstance();
-        $instance->expects($this->once())->method('onServerActivity');
+        $instance->expects($this->once())->method('onPotentialConnectionStateActivity');
         $instance->emptyBuffer();
     }
 


### PR DESCRIPTION
When no data is available, we should not update server activity timestamp.
Instead, ask if something is going wrong.
Fixes stomp-php/stomp-php#148
Due to stomp-php/stomp-php@3f354382cf79be1e1b2133980ac45f51074adaf5