### PR TITLE
#154 Add option to set the subscription id for durable subscriptions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 
 sudo: true
 
+env:
+  global:
+    - XDEBUG_MODE=coverage
+
 services:
   - docker
 

--- a/src/Broker/ActiveMq/ActiveMq.php
+++ b/src/Broker/ActiveMq/ActiveMq.php
@@ -53,7 +53,7 @@ class ActiveMq extends Protocol
         $frame['activemq.prefetchSize'] = $this->prefetchSize;
         if ($durable) {
             $frame['activemq.subscriptionName'] = $this->getClientId();
-            $frame['activemq.durable-subscription-name'] = $subscriptionId;
+            $frame['durable-subscriber-name'] = $subscriptionId;
         }
         return $frame;
     }
@@ -71,7 +71,7 @@ class ActiveMq extends Protocol
         $frame = parent::getUnsubscribeFrame($destination, $subscriptionId);
         if ($durable) {
             $frame['activemq.subscriptionName'] = $this->getClientId();
-            $frame['durable-subscription-name'] = $subscriptionId;
+            $frame['durable-subscriber-name'] = $subscriptionId;
         }
         return $frame;
     }

--- a/src/Broker/ActiveMq/ActiveMq.php
+++ b/src/Broker/ActiveMq/ActiveMq.php
@@ -52,7 +52,8 @@ class ActiveMq extends Protocol
         $frame = parent::getSubscribeFrame($destination, $subscriptionId, $ack, $selector);
         $frame['activemq.prefetchSize'] = $this->prefetchSize;
         if ($durable) {
-            $frame['activemq.subscriptionName'] = $subscriptionId;
+            $frame['activemq.subscriptionName'] = $this->getClientId();
+            $frame['activemq.durable-subscription-name'] = $subscriptionId;
         }
         return $frame;
     }
@@ -69,7 +70,8 @@ class ActiveMq extends Protocol
     {
         $frame = parent::getUnsubscribeFrame($destination, $subscriptionId);
         if ($durable) {
-            $frame['activemq.subscriptionName'] = $subscriptionId;
+            $frame['activemq.subscriptionName'] = $this->getClientId();
+            $frame['durable-subscription-name'] = $subscriptionId;
         }
         return $frame;
     }

--- a/src/Broker/ActiveMq/ActiveMq.php
+++ b/src/Broker/ActiveMq/ActiveMq.php
@@ -69,7 +69,7 @@ class ActiveMq extends Protocol
     {
         $frame = parent::getUnsubscribeFrame($destination, $subscriptionId);
         if ($durable) {
-            $frame['activemq.subscriptionName'] = $this->getClientId();
+            $frame['activemq.subscriptionName'] = $subscriptionId;
         }
         return $frame;
     }

--- a/src/Broker/ActiveMq/ActiveMq.php
+++ b/src/Broker/ActiveMq/ActiveMq.php
@@ -52,7 +52,7 @@ class ActiveMq extends Protocol
         $frame = parent::getSubscribeFrame($destination, $subscriptionId, $ack, $selector);
         $frame['activemq.prefetchSize'] = $this->prefetchSize;
         if ($durable) {
-            $frame['activemq.subscriptionName'] = $this->getClientId();
+            $frame['activemq.subscriptionName'] = $subscriptionId;
         }
         return $frame;
     }

--- a/src/Broker/ActiveMq/Mode/DurableSubscription.php
+++ b/src/Broker/ActiveMq/Mode/DurableSubscription.php
@@ -49,7 +49,7 @@ class DurableSubscription extends ActiveMqMode
             throw new StompException('Client must have been configured to use a specific clientId!');
         }
         $subscriptionId = $subscriptionId ?? $client->getClientId();
-        $this->subscription = new Subscription($topic, $selector, $ack, $client->getClientId());
+        $this->subscription = new Subscription($topic, $selector, $ack, $subscriptionId);
     }
 
     /**

--- a/src/Broker/ActiveMq/Mode/DurableSubscription.php
+++ b/src/Broker/ActiveMq/Mode/DurableSubscription.php
@@ -48,6 +48,10 @@ class DurableSubscription extends ActiveMqMode
         if (!$client->getClientId()) {
             throw new StompException('Client must have been configured to use a specific clientId!');
         }
+        $server = $client->getProtocol()->getServer();
+        if (is_null($subscriptionId) && substr($server, 0, 16) === 'ActiveMQ-Artemis') {
+            throw new StompException('Durable subscription requires a specific subscriptionId!');
+        }
         $subscriptionId = isset($subscriptionId) ? $subscriptionId : $client->getClientId();
         $this->subscription = new Subscription($topic, $selector, $ack, $subscriptionId);
     }

--- a/src/Broker/ActiveMq/Mode/DurableSubscription.php
+++ b/src/Broker/ActiveMq/Mode/DurableSubscription.php
@@ -42,7 +42,7 @@ class DurableSubscription extends ActiveMqMode
      * @param string $subscriptionId
      * @throws StompException
      */
-    public function __construct(Client $client, $topic, $selector = null, $ack = 'auto', $subscriptionId = NULL)
+    public function __construct(Client $client, $topic, $selector = null, $ack = 'auto', $subscriptionId = null)
     {
         parent::__construct($client);
         if (!$client->getClientId()) {

--- a/src/Broker/ActiveMq/Mode/DurableSubscription.php
+++ b/src/Broker/ActiveMq/Mode/DurableSubscription.php
@@ -39,14 +39,16 @@ class DurableSubscription extends ActiveMqMode
      * @param string $topic
      * @param string $selector
      * @param string $ack
+     * @param string $subscriptionId
      * @throws StompException
      */
-    public function __construct(Client $client, $topic, $selector = null, $ack = 'auto')
+    public function __construct(Client $client, $topic, $selector = null, $ack = 'auto', $subscriptionId = NULL)
     {
         parent::__construct($client);
         if (!$client->getClientId()) {
             throw new StompException('Client must have been configured to use a specific clientId!');
         }
+        $subscriptionId = $subscriptionId ?? $client->getClientId();
         $this->subscription = new Subscription($topic, $selector, $ack, $client->getClientId());
     }
 

--- a/src/Broker/ActiveMq/Mode/DurableSubscription.php
+++ b/src/Broker/ActiveMq/Mode/DurableSubscription.php
@@ -48,7 +48,7 @@ class DurableSubscription extends ActiveMqMode
         if (!$client->getClientId()) {
             throw new StompException('Client must have been configured to use a specific clientId!');
         }
-        $subscriptionId = $subscriptionId ?? $client->getClientId();
+        $subscriptionId = isset($subscriptionId) ? $subscriptionId : $client->getClientId();
         $this->subscription = new Subscription($topic, $selector, $ack, $subscriptionId);
     }
 

--- a/tests/Unit/Broker/ActiveMq/ActiveMqTest.php
+++ b/tests/Unit/Broker/ActiveMq/ActiveMqTest.php
@@ -51,7 +51,8 @@ class ActiveMqTest extends ProtocolTestCase
          */
         $result = $instance->getSubscribeFrame('target', 'test-durable-subscriber-name', 'auto', null, true);
         $this->assertEquals($instance->getPrefetchSize(), $result['activemq.prefetchSize']);
-        $this->assertEquals('test-durable-subscriber-name', $result['activemq.subscriptionName']);
+        $this->assertEquals('test-client-id', $result['activemq.subscriptionName']);
+        $this->assertEquals('test-durable-subscriber-name', $result['durable-subscription-name']);
     }
 
     public function testUnsubscribeNonDurable()
@@ -68,7 +69,8 @@ class ActiveMqTest extends ProtocolTestCase
          * @var $instance ActiveMq
          */
         $result = $instance->getUnsubscribeFrame('target', 'test-durable-subscriber-name', true);
-        $this->assertEquals('test-durable-subscriber-name', $result['activemq.subscriptionName']);
+        $this->assertEquals('test-client-id', $result['activemq.subscriptionName']);
+        $this->assertEquals('test-durable-subscriber-name', $result['durable-subscription-name']);
     }
 
     public function testAckVersionZero()

--- a/tests/Unit/Broker/ActiveMq/ActiveMqTest.php
+++ b/tests/Unit/Broker/ActiveMq/ActiveMqTest.php
@@ -49,9 +49,9 @@ class ActiveMqTest extends ProtocolTestCase
         /**
          * @var $instance ActiveMq
          */
-        $result = $instance->getSubscribeFrame('target', null, 'auto', null, true);
+        $result = $instance->getSubscribeFrame('target', 'test-durable-subscriber-name', 'auto', null, true);
         $this->assertEquals($instance->getPrefetchSize(), $result['activemq.prefetchSize']);
-        $this->assertEquals('test-client-id', $result['activemq.subscriptionName']);
+        $this->assertEquals('test-durable-subscriber-name', $result['activemq.subscriptionName']);
     }
 
     public function testUnsubscribeNonDurable()
@@ -67,8 +67,8 @@ class ActiveMqTest extends ProtocolTestCase
         /**
          * @var $instance ActiveMq
          */
-        $result = $instance->getUnsubscribeFrame('target', null, true);
-        $this->assertEquals('test-client-id', $result['activemq.subscriptionName']);
+        $result = $instance->getUnsubscribeFrame('target', 'test-durable-subscriber-name', true);
+        $this->assertEquals('test-durable-subscriber-name', $result['activemq.subscriptionName']);
     }
 
     public function testAckVersionZero()

--- a/tests/Unit/Broker/ActiveMq/ActiveMqTest.php
+++ b/tests/Unit/Broker/ActiveMq/ActiveMqTest.php
@@ -52,7 +52,7 @@ class ActiveMqTest extends ProtocolTestCase
         $result = $instance->getSubscribeFrame('target', 'test-durable-subscriber-name', 'auto', null, true);
         $this->assertEquals($instance->getPrefetchSize(), $result['activemq.prefetchSize']);
         $this->assertEquals('test-client-id', $result['activemq.subscriptionName']);
-        $this->assertEquals('test-durable-subscriber-name', $result['durable-subscription-name']);
+        $this->assertEquals('test-durable-subscriber-name', $result['durable-subscriber-name']);
     }
 
     public function testUnsubscribeNonDurable()
@@ -70,7 +70,7 @@ class ActiveMqTest extends ProtocolTestCase
          */
         $result = $instance->getUnsubscribeFrame('target', 'test-durable-subscriber-name', true);
         $this->assertEquals('test-client-id', $result['activemq.subscriptionName']);
-        $this->assertEquals('test-durable-subscriber-name', $result['durable-subscription-name']);
+        $this->assertEquals('test-durable-subscriber-name', $result['durable-subscriber-name']);
     }
 
     public function testAckVersionZero()


### PR DESCRIPTION
> To create a durable subscription the client-id header must be set on the CONNECT frame and the durable-subscription-name must be set on the SUBSCRIBE frame. The combination of these two headers will form the identity of the durable subscription.
> 
> Aside from durable-subscription-name, the broker also supports durable-subscriber-name (a deprecated property used before durable-subscription-name) as well as activemq.subscriptionName from ActiveMQ 5.x. This is the order of precedence if the frame contains more than one of these:
> 
> 1) durable-subscriber-name 2) durable-subscription-name 3) activemq.subscriptionName

Source https://activemq.apache.org/components/artemis/documentation/2.7.0/stomp.html#durable-subscriptions

Note: for AMQ 5.6 the client-id should be identical to the subscriptionName. This is no longer valid for Artemis.
https://stackoverflow.com/questions/13137557/activemq-durable-consumer-is-in-use-for-client-and-subscriptionname-via-stomp/13146955#13146955

So instead of sending the activemq.subscriptionName header with the client-id in the SUBSCRIBE frame, we should send the durable-subscription-name header for Artemis.

The code in the PR adds support for backwards compatibility.