### PR TITLE
PHP 7.4, PHPUnit 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 jobs:
   include:
     - &TEST
-      php: "5.6"
+      php: "7.3"
       before_script:
         - ./travisci/bin/start.sh
         - composer install
@@ -22,14 +22,6 @@ jobs:
 
       after_script:
         - ./travisci/bin/stop.sh
-    - <<: *TEST
-      php: "7.0"
-    - <<: *TEST
-      php: "7.1"
-    - <<: *TEST
-      php: "7.2"
-    - <<: *TEST
-      php: "7.3"
     - <<: *TEST
       php: "7.4"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,11 @@ jobs:
       php: "7.2"
     - <<: *TEST
       php: "7.3"
+    - <<: *TEST
+      php: "7.4"
 
     - stage: Static analysis with phpstan
-      php: "7.3"
+      php: "7.4"
       script:
         - composer require --dev phpstan/phpstan
         - vendor/bin/phpstan analyse

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,16 +10,15 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "false"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "tests/bootstrap.php" >
-    <filter>
-        <blacklist>
-            <directory>vendor</directory>
-        </blacklist>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory>src/</directory>
+        </include>
+        <exclude>
+            <directory>vendor/</directory>
+        </exclude>
+    </coverage>
     <testsuites>
         <testsuite name="stomp-php Functional Test Suite">
             <directory>tests/Functional/</directory>

--- a/tests/Cases/PCNTL/StreamSignalTest.php
+++ b/tests/Cases/PCNTL/StreamSignalTest.php
@@ -74,8 +74,8 @@ class StreamSignalTest extends TestCase
         fclose($pipes[1]);
         fclose($pipes[2]);
         $returnCode = proc_close($process);
-        $this->assertContains('INFO: Started to listen for new messages...', $output);
-        $this->assertContains('TEST: SUCCEEDED', $output);
+        $this->assertStringContainsString('INFO: Started to listen for new messages...', $output);
+        $this->assertStringContainsString('TEST: SUCCEEDED', $output);
         $this->assertEquals(0, $returnCode);
     }
 }

--- a/tests/Functional/ActiveMq/ASyncTest.php
+++ b/tests/Functional/ActiveMq/ASyncTest.php
@@ -34,7 +34,7 @@ class ASyncTest extends TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->Stomp = ClientProvider::getClient();
@@ -45,7 +45,7 @@ class ASyncTest extends TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->Stomp->disconnect(true);
         $this->Stomp = null;

--- a/tests/Functional/ActiveMq/ClientTest.php
+++ b/tests/Functional/ActiveMq/ClientTest.php
@@ -42,7 +42,7 @@ class ClientTest extends TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -52,7 +52,7 @@ class ClientTest extends TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->Stomp = null;
         parent::tearDown();

--- a/tests/Functional/ActiveMq/ClientTest.php
+++ b/tests/Functional/ActiveMq/ClientTest.php
@@ -439,6 +439,8 @@ class ClientTest extends TestCase
 
     public function testSendAlive()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->Stomp->connect();
         $this->Stomp->getConnection()->sendAlive();
         $this->Stomp->disconnect();

--- a/tests/Functional/ActiveMq/StatefulTest.php
+++ b/tests/Functional/ActiveMq/StatefulTest.php
@@ -8,6 +8,7 @@
 
 namespace Stomp\Tests\Functional\ActiveMq;
 
+use LogicException;
 use Stomp\Tests\Functional\Stomp\StatefulTestBase;
 use Stomp\Transport\Frame;
 use Stomp\Transport\Message;
@@ -51,9 +52,6 @@ class StatefulTest extends StatefulTestBase
         $receiver->unsubscribe();
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testNackRequeueException()
     {
         $queue = '/queue/tests-ack-nack';
@@ -65,6 +63,8 @@ class StatefulTest extends StatefulTestBase
         $producer->send($queue, new Message('message-a', ['persistent' => 'true']));
         $producer->send($queue, new Message('message-b', ['persistent' => 'true']));
         $producer->getClient()->disconnect(true);
+
+        $this->expectException(LogicException::class);
 
         $frameA = $receiver->read();
         $receiver->nack($frameA, true);

--- a/tests/Functional/ActiveMq/SyncTest.php
+++ b/tests/Functional/ActiveMq/SyncTest.php
@@ -33,7 +33,7 @@ class SyncTest extends TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +44,7 @@ class SyncTest extends TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->Stomp->disconnect();
         $this->Stomp = null;

--- a/tests/Functional/ApolloMq/ClientTest.php
+++ b/tests/Functional/ApolloMq/ClientTest.php
@@ -26,7 +26,7 @@ class ClientTest extends TestCase
     private $client;
 
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = ClientProvider::getClient();

--- a/tests/Functional/ApolloMq/Mode/QueueBrowserTest.php
+++ b/tests/Functional/ApolloMq/Mode/QueueBrowserTest.php
@@ -22,7 +22,7 @@ use Stomp\Transport\Message;
  */
 class QueueBrowserTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/Functional/ApolloMq/Mode/SequenceQueueBrowserTest.php
+++ b/tests/Functional/ApolloMq/Mode/SequenceQueueBrowserTest.php
@@ -22,7 +22,7 @@ use Stomp\Transport\Message;
  */
 class SequenceQueueBrowserTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/Functional/ApolloMq/StatefulTest.php
+++ b/tests/Functional/ApolloMq/StatefulTest.php
@@ -8,6 +8,7 @@
 
 namespace Stomp\Tests\Functional\ApolloMq;
 
+use LogicException;
 use Stomp\Tests\Functional\Stomp\StatefulTestBase;
 use Stomp\Transport\Message;
 
@@ -24,9 +25,6 @@ class StatefulTest extends StatefulTestBase
         return ClientProvider::getClient();
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testNackRequeueException()
     {
         $queue = '/queue/tests-ack-nack-exception';
@@ -38,6 +36,8 @@ class StatefulTest extends StatefulTestBase
         $producer->send($queue, new Message('message-a', ['persistent' => 'true']));
         $producer->send($queue, new Message('message-b', ['persistent' => 'true']));
         $producer->getClient()->disconnect(true);
+
+        $this->expectException(LogicException::class);
 
         $frameA = $receiver->read();
         $receiver->nack($frameA, true);

--- a/tests/Functional/Artemis/ASyncTest.php
+++ b/tests/Functional/Artemis/ASyncTest.php
@@ -34,7 +34,7 @@ class ASyncTest extends TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->Stomp = ClientProvider::getClient();
@@ -45,7 +45,7 @@ class ASyncTest extends TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->Stomp->disconnect(true);
         $this->Stomp = null;

--- a/tests/Functional/Artemis/ClientTest.php
+++ b/tests/Functional/Artemis/ClientTest.php
@@ -42,7 +42,7 @@ class ClientTest extends TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -52,7 +52,7 @@ class ClientTest extends TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->Stomp = null;
         parent::tearDown();

--- a/tests/Functional/Artemis/ClientTest.php
+++ b/tests/Functional/Artemis/ClientTest.php
@@ -437,6 +437,8 @@ class ClientTest extends TestCase
 
     public function testSendAlive()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->Stomp->connect();
         $this->Stomp->getConnection()->sendAlive();
         $this->Stomp->disconnect();

--- a/tests/Functional/Artemis/StatefulTest.php
+++ b/tests/Functional/Artemis/StatefulTest.php
@@ -8,6 +8,7 @@
 
 namespace Stomp\Tests\Functional\Artemis;
 
+use LogicException;
 use Stomp\Tests\Functional\Stomp\StatefulTestBase;
 use Stomp\Transport\Frame;
 use Stomp\Transport\Message;
@@ -51,9 +52,6 @@ class StatefulTest extends StatefulTestBase
         $receiver->unsubscribe();
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testNackRequeueException()
     {
         $queue = 'queue/tests-ack-nack-add-again';
@@ -65,6 +63,8 @@ class StatefulTest extends StatefulTestBase
         $producer->send($queue, new Message('message-a', ['persistent' => 'true']));
         $producer->send($queue, new Message('message-b', ['persistent' => 'true']));
         $producer->getClient()->disconnect(true);
+
+        $this->expectException(LogicException::class);
 
         $frameA = $receiver->read();
         $receiver->nack($frameA, true);

--- a/tests/Functional/Artemis/SyncTest.php
+++ b/tests/Functional/Artemis/SyncTest.php
@@ -33,7 +33,7 @@ class SyncTest extends TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +44,7 @@ class SyncTest extends TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->Stomp->disconnect();
         $this->Stomp = null;

--- a/tests/Functional/Generic/ConnectionTest.php
+++ b/tests/Functional/Generic/ConnectionTest.php
@@ -42,7 +42,7 @@ class ConnectionTest extends TestCase
             $connection->readFrame();
             $this->fail('Expected a exception!');
         } catch (ConnectionException $exception) {
-            $this->assertContains('Was not possible to read data from stream.', $exception->getMessage());
+            $this->assertStringContainsString('Was not possible to read data from stream.', $exception->getMessage());
         }
     }
 
@@ -68,7 +68,7 @@ class ConnectionTest extends TestCase
             $connection->readFrame();
             $this->fail('Expected a exception!');
         } catch (ErrorFrameException $exception) {
-            $this->assertContains('stomp-err-info', $exception->getMessage());
+            $this->assertStringContainsString('stomp-err-info', $exception->getMessage());
             $this->assertEquals('body', $exception->getFrame()->body);
         }
         fclose($fp);
@@ -93,7 +93,7 @@ class ConnectionTest extends TestCase
             $connection->writeFrame(new Frame('TEST'));
             $this->fail('Expected a exception!');
         } catch (ConnectionException $exception) {
-            $this->assertContains('Was not possible to write frame!', $exception->getMessage());
+            $this->assertStringContainsString('Was not possible to write frame!', $exception->getMessage());
         }
         fclose($fp);
     }
@@ -129,7 +129,7 @@ class ConnectionTest extends TestCase
             $connection->readFrame();
             $this->fail('Expected a exception!');
         } catch (ConnectionException $exception) {
-            $this->assertContains('Check failed to determine if the socket is readable', $exception->getMessage());
+            $this->assertStringContainsString('Check failed to determine if the socket is readable', $exception->getMessage());
         }
     }
 
@@ -140,7 +140,7 @@ class ConnectionTest extends TestCase
             $connection->connect();
             $this->fail('Expected an exception!');
         } catch (ConnectionException $ex) {
-            $this->assertContains('Could not connect to a broker', $ex->getMessage());
+            $this->assertStringContainsString('Could not connect to a broker', $ex->getMessage());
 
             $this->assertInstanceOf(
                 ConnectionException::class,

--- a/tests/Functional/Generic/ConnectionTest.php
+++ b/tests/Functional/Generic/ConnectionTest.php
@@ -9,6 +9,7 @@
 
 namespace Stomp\Tests\Functional\Generic;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Stomp\Exception\ConnectionException;
 use Stomp\Exception\ErrorFrameException;
@@ -24,7 +25,7 @@ class ConnectionTest extends TestCase
 {
     public function testReadFrameThrowsExceptionIfStreamIsBroken()
     {
-        /** @var Connection|\PHPUnit_Framework_MockObject_MockObject $connection */
+        /** @var Connection|MockObject $connection */
         $connection = $this->getMockBuilder(Connection::class)
             ->setMethods(['hasDataToRead', 'connectSocket'])
             ->setConstructorArgs(['tcp://host'])
@@ -47,7 +48,7 @@ class ConnectionTest extends TestCase
 
     public function testReadFrameThrowsExceptionIfErrorFrameIsReceived()
     {
-        /** @var \Stomp\Network\Connection|\PHPUnit_Framework_MockObject_MockObject $connection */
+        /** @var \Stomp\Network\Connection|MockObject $connection */
         $connection = $this->getMockBuilder(Connection::class)
             ->setMethods(['hasDataToRead', 'connectSocket'])
             ->setConstructorArgs(['tcp://host'])
@@ -75,7 +76,7 @@ class ConnectionTest extends TestCase
 
     public function testWriteFrameThrowsExceptionIfConnectionIsBroken()
     {
-        /** @var \Stomp\Network\Connection|\PHPUnit_Framework_MockObject_MockObject $connection */
+        /** @var \Stomp\Network\Connection|MockObject $connection */
         $connection = $this->getMockBuilder(Connection::class)
             ->setMethods(['connectSocket'])
             ->setConstructorArgs(['tcp://host'])
@@ -99,7 +100,7 @@ class ConnectionTest extends TestCase
 
     public function testHasDataToReadThrowsExceptionIfConnectionIsBroken()
     {
-        /** @var \Stomp\Network\Connection|\PHPUnit_Framework_MockObject_MockObject $connection */
+        /** @var \Stomp\Network\Connection|MockObject $connection */
         $connection = $this->getMockBuilder(Connection::class)
             ->setMethods(['isConnected', 'connectSocket'])
             ->setConstructorArgs(['tcp://host'])

--- a/tests/Functional/Generic/StompFailoverTest.php
+++ b/tests/Functional/Generic/StompFailoverTest.php
@@ -28,7 +28,7 @@ class StompFailoverTest extends TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -41,7 +41,7 @@ class StompFailoverTest extends TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->Stomp->disconnect();
         $this->Stomp = null;

--- a/tests/Functional/RabbitMq/ClientTest.php
+++ b/tests/Functional/RabbitMq/ClientTest.php
@@ -40,7 +40,7 @@ class ClientTest extends TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -51,7 +51,7 @@ class ClientTest extends TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->stomp->isConnected()) {
             $this->stomp->disconnect();

--- a/tests/Functional/Stomp/StatefulTestBase.php
+++ b/tests/Functional/Stomp/StatefulTestBase.php
@@ -28,7 +28,7 @@ abstract class StatefulTestBase extends TestCase
      */
     private $clients = [];
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->clients as $client) {
             if ($client->isConnected()) {

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -39,7 +39,7 @@ class ClientTest extends TestCase
      */
     private static $stomp;
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$stomp = null;
         parent::tearDownAfterClass();

--- a/tests/Unit/Network/ConnectionTest.php
+++ b/tests/Unit/Network/ConnectionTest.php
@@ -204,12 +204,10 @@ class ConnectionTest extends TestCase
         stream_wrapper_unregister('stompFakeStream');
     }
 
-
-    /**
-     * @expectedException  \Stomp\Exception\ConnectionException
-     */
     public function testSendAliveWillCauseConnectionException()
     {
+        $this->expectException(ConnectionException::class);
+
         stream_wrapper_register('stompFakeStream', FakeStream::class);
 
 
@@ -236,7 +234,7 @@ class ConnectionTest extends TestCase
         fclose($fakeStreamResource);
         stream_wrapper_unregister('stompFakeStream');
         if (!$exception) {
-            $this->fail('Excepted exception.');
+            $this->fail('Expected exception.');
         }
         throw $exception;
     }

--- a/tests/Unit/Network/ConnectionTest.php
+++ b/tests/Unit/Network/ConnectionTest.php
@@ -10,6 +10,7 @@
 namespace Stomp\Tests\Unit\Network;
 
 use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Stomp\Exception\ConnectionException;
@@ -117,7 +118,7 @@ class ConnectionTest extends TestCase
 
     public function testConnectionSetupTriesFullHostListBeforeGivingUp()
     {
-        /** @var Connection|\PHPUnit_Framework_MockObject_MockObject $connection */
+        /** @var Connection|MockObject $connection */
         $connection = $this->getMockBuilder(Connection::class)
             ->setMethods(['connectSocket'])
             ->setConstructorArgs(['failover://(tcp://host1,tcp://host2,tcp://host3)'])

--- a/tests/Unit/Network/ConnectionTest.php
+++ b/tests/Unit/Network/ConnectionTest.php
@@ -143,7 +143,7 @@ class ConnectionTest extends TestCase
             $connection->connect();
             $this->fail('No connection was established, expected exception!');
         } catch (Exception $ex) {
-            $this->assertContains('Could not connect to a broker', $ex->getMessage());
+            $this->assertStringContainsString('Could not connect to a broker', $ex->getMessage());
         }
     }
 

--- a/tests/Unit/Network/ConnectionTest.php
+++ b/tests/Unit/Network/ConnectionTest.php
@@ -42,7 +42,7 @@ class ConnectionTest extends TestCase
     /**
      * Data provider for testBrokerUriShouldRandomizeHosts().
      */
-    public function testBrokerUriShouldRandomizeHostsProvider()
+    public function brokerUriProvider()
     {
         return [
             'non-failover URI' => ['tcp://host1:61614', false],
@@ -60,7 +60,7 @@ class ConnectionTest extends TestCase
      * @param bool $expected
      *   The expected result, TRUE/FALSE.
      *
-     * @dataProvider testBrokerUriShouldRandomizeHostsProvider
+     * @dataProvider brokerUriProvider
      */
     public function testBrokerUriShouldRandomizeHosts($uri, $expected)
     {

--- a/tests/Unit/Network/Observer/AbstractBeatsTest.php
+++ b/tests/Unit/Network/Observer/AbstractBeatsTest.php
@@ -8,6 +8,7 @@
 
 namespace Stomp\Tests\Unit\Network\Observer;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Stomp\Network\Observer\AbstractBeats;
 use Stomp\Transport\Frame;
@@ -161,11 +162,11 @@ class AbstractBeatsTest extends TestCase
      * Injects a function that will update the last detected beat whenever a server signal is received.
      *
      * @noinspection PhpDocMissingThrowsInspection
-     * @param \PHPUnit_Framework_MockObject_MockObject|AbstractBeats $instance
+     * @param MockObject|AbstractBeats $instance
      * @param $interval
      */
     private function injectActivatedWithServerActivityBeatUpdate(
-        \PHPUnit_Framework_MockObject_MockObject $instance,
+        MockObject $instance,
         $interval
     ) {
         $frame = $this->getServerConnectedFrame($interval, $interval);
@@ -185,13 +186,13 @@ class AbstractBeatsTest extends TestCase
     /**
      * Assert that the instance will be enabled when a frame with heartbeat details is detected.
      *
-     * @param \PHPUnit_Framework_MockObject_MockObject|AbstractBeats $instance
+     * @param MockObject|AbstractBeats $instance
      * @param Frame $frame
      * @param integer $intervalServer
      * @param integer $intervalClient
      */
     private function assertEnabledOnce(
-        \PHPUnit_Framework_MockObject_MockObject $instance,
+        MockObject $instance,
         Frame $frame,
         $intervalServer,
         $intervalClient
@@ -241,7 +242,7 @@ class AbstractBeatsTest extends TestCase
     /**
      * Generates a beat instance.
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject|AbstractBeats
+     * @return MockObject|AbstractBeats
      */
     private function getInstance()
     {

--- a/tests/Unit/Network/Observer/ConnectionObserverCollectionTest.php
+++ b/tests/Unit/Network/Observer/ConnectionObserverCollectionTest.php
@@ -26,7 +26,7 @@ class ConnectionObserverCollectionTest extends TestCase
      */
     private $instance;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->instance = new ConnectionObserverCollection();

--- a/tests/Unit/Network/Observer/HeartbeatEmitterTest.php
+++ b/tests/Unit/Network/Observer/HeartbeatEmitterTest.php
@@ -38,7 +38,7 @@ class HeartbeatEmitterTest extends TestCase
      */
     private $connection;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = $this->getMockBuilder(Connection::class)

--- a/tests/Unit/Network/Observer/ServerAliveObserverTest.php
+++ b/tests/Unit/Network/Observer/ServerAliveObserverTest.php
@@ -10,6 +10,7 @@ namespace Stomp\Tests\Unit\Network\Observer;
 
 use PHPUnit\Framework\TestCase;
 use Stomp\Network\Observer\AbstractBeats;
+use Stomp\Network\Observer\Exception\HeartbeatException;
 use Stomp\Network\Observer\ServerAliveObserver;
 use Stomp\Transport\Frame;
 
@@ -46,12 +47,11 @@ class ServerAliveObserverTest extends TestCase
         self::assertEquals(20, $method->invoke($instance, 4));
     }
 
-    /**
-     * @expectedExceptionMessage The server failed to send expected heartbeats.
-     * @expectedException \Stomp\Network\Observer\Exception\HeartbeatException
-     */
     public function testOnDelayThrowsException()
     {
+        $this->expectException(HeartbeatException::class);
+        $this->expectExceptionMessage('The server failed to send expected heartbeats.');
+
         $instance = new ServerAliveObserver();
         $method = new \ReflectionMethod($instance, 'onDelay');
         $method->setAccessible(true);

--- a/tests/Unit/Protocol/ProtocolTestCase.php
+++ b/tests/Unit/Protocol/ProtocolTestCase.php
@@ -61,7 +61,7 @@ abstract class ProtocolTestCase extends TestCase
             $protocol->getSubscribeFrame('my-destination', 'my-sub-id', 'my-ack', 'my-selector');
             $this->fail();
         } catch (StompException $e) {
-            $this->assertContains('"my-ack" is not a valid ack value', $e->getMessage());
+            $this->assertStringContainsString('"my-ack" is not a valid ack value', $e->getMessage());
         }
     }
 

--- a/tests/Unit/Transport/FrameFactoryTest.php
+++ b/tests/Unit/Transport/FrameFactoryTest.php
@@ -27,7 +27,7 @@ class FrameFactoryTest extends TestCase
      */
     private $instance;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->instance = new FrameFactory();

--- a/tests/Unit/Transport/ParserTest.php
+++ b/tests/Unit/Transport/ParserTest.php
@@ -30,7 +30,7 @@ class ParserTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();


### PR DESCRIPTION
- Add PHP 7.4 to the build matrix;
- 7.4 introduced some deprecations for PHPUnit, only fixed in 8.2.3 => update PHPUnit to 9.5;
- Drop PHP < 7.3 (unsupported by newer PHPUnit and are EOL anyway);
- Adapt tests to newer PHPUnit.