### PR TITLE
PHP 8.1: Return types in PHP built-in class methods and deprecation notices

### DIFF
--- a/src/States/Meta/SubscriptionList.php
+++ b/src/States/Meta/SubscriptionList.php
@@ -59,7 +59,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return \Iterator|Subscription[]
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->subscriptions);
     }
@@ -69,7 +69,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->subscriptions[$offset]);
     }
@@ -79,7 +79,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return Subscription
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->subscriptions[$offset];
     }
@@ -87,7 +87,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * @inheritdoc
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->subscriptions[$offset] = $value;
     }
@@ -95,7 +95,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * @inheritdoc
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->subscriptions[$offset]);
     }
@@ -103,7 +103,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * @inheritdoc
      */
-    public function count()
+    public function count(): int
     {
         return count($this->subscriptions);
     }

--- a/src/Transport/Frame.php
+++ b/src/Transport/Frame.php
@@ -212,7 +212,7 @@ class Frame implements ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->headers[$offset]);
     }
@@ -220,7 +220,7 @@ class Frame implements ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         if (isset($this->headers[$offset])) {
             return $this->headers[$offset];
@@ -231,7 +231,7 @@ class Frame implements ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if ($value !== null) {
             $this->headers[$offset] = $value;
@@ -242,7 +242,7 @@ class Frame implements ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->headers[$offset]);
     }


### PR DESCRIPTION
See [php watch ](https://php.watch/versions/8.1/internal-method-return-types) for more info