### PR TITLE
Fix Actions and update PHP matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup ActiveMq
-        run: docker run --rm -d --name stomp-activemq -v ${{ github.workspace }}/travisci/conf/amq/activemq.xml:/opt/activemq/conf/activemq.xml:ro -p 127.0.0.1:61010:61010 rmohr/activemq:${{ vars.ACTIVEMQ_IMAGE_TAG }}
-
-      - name: Setup Apollo
-        run: docker run --rm -d --name stomp-apollo -p 127.0.0.1:61020:61020 finsn/stomp-apollo:${{ vars.APOLLO_IMAGE_TAG }}
-
-      - name: Setup Artemis
-        run: docker run --rm -d --name stomp-artemis -p 127.0.0.1:61040:61613 -e DISABLE_SECURITY=true -v ${{ github.workspace }}/travisci/conf/artemis/broker-00.xml:/var/lib/artemis/etc-override/broker-00.xml:ro vromero/activemq-artemis:${{ vars.ARTEMIS_IMAGE_TAG }}
-
-      - name: Setup RabbitMq
-        run: docker run --rm -d --name stomp-rabbit -p 127.0.0.1:61030:61030 -v ${{ github.workspace }}/travisci/conf/rabbit/:/etc/rabbitmq/ rabbitmq:${{ vars.RABBITMQ_IMAGE_TAG }}
+      - name: Setup Brokers
+        run: ./travisci/bin/start.sh
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -69,4 +60,6 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run tests
-        run: vendor/bin/phpunit --debug
+        run: |
+          ./travisci/bin/logs.sh
+          vendor/bin/phpunit --debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4', '8.0']
+        php: ['7.3', '7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php }} tests
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,44 +1,72 @@
 name: CI
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - 'master'
+  push:
+    branches:
+      - '**'
+
 jobs:
   static_analysis:
     name: Static analysis with phpstan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
+          tools: phpstan, composer:v2
 
-      - uses: "ramsey/composer-install@v1"
-
-      - run: composer require --dev phpstan/phpstan
-
-      - run: vendor/bin/phpstan analyse
+      - run: phpstan analyse
 
   tests:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        php: ['7.3', '7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1', '8.2']
     name: PHP ${{ matrix.php }} tests
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - uses: shivammathur/setup-php@v2
+      - name: Setup ActiveMq
+        run: docker run --rm -d --name stomp-activemq -v ${{ github.workspace }}/travisci/conf/amq/activemq.xml:/opt/activemq/conf/activemq.xml:ro -p 127.0.0.1:61010:61010 rmohr/activemq:${{ vars.ACTIVEMQ_IMAGE_TAG }}
+
+      - name: Setup Apollo
+        run: docker run --rm -d --name stomp-apollo -p 127.0.0.1:61020:61020 finsn/stomp-apollo:${{ vars.APOLLO_IMAGE_TAG }}
+
+      - name: Setup Artemis
+        run: docker run --rm -d --name stomp-artemis -p 127.0.0.1:61040:61613 -e DISABLE_SECURITY=true -v ${{ github.workspace }}/travisci/conf/artemis/broker-00.xml:/var/lib/artemis/etc-override/broker-00.xml:ro vromero/activemq-artemis:${{ vars.ARTEMIS_IMAGE_TAG }}
+
+      - name: Setup RabbitMq
+        run: docker run --rm -d --name stomp-rabbit -p 127.0.0.1:61030:61030 -v ${{ github.workspace }}/travisci/conf/rabbit/:/etc/rabbitmq/ rabbitmq:${{ vars.RABBITMQ_IMAGE_TAG }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
           ini-values: error_reporting=E_ALL
+          tools: composer:v2
 
-      - run: ./travisci/bin/start.sh
+      - name: Get composer cache directory
+        id: composercache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-      - uses: "ramsey/composer-install@v1"
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
-      - run: |
-          ./travisci/bin/logs.sh
-          vendor/bin/phpunit --debug
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
 
-      - run: ./travisci/bin/stop.sh
+      - name: Run tests
+        run: vendor/bin/phpunit --debug

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 /.project
 /travisci/tmp
 stomp-php.iml
+.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<!-- https://phpunit.readthedocs.io/en/stable/configuration.html -->
 <phpunit
-    backupGlobals               = "false"
-    backupStaticAttributes      = "false"
-    colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
-    bootstrap                   = "tests/bootstrap.php" >
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertDeprecationsToExceptions="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="tests/bootstrap.php"
+>
     <coverage>
         <include>
             <directory>src/</directory>
@@ -18,6 +20,9 @@
         <exclude>
             <directory>vendor/</directory>
         </exclude>
+        <report>
+            <text outputFile="php://stdout" showUncoveredFiles="true"/>
+        </report>
     </coverage>
     <testsuites>
         <testsuite name="stomp-php Functional Test Suite">
@@ -30,7 +35,7 @@
             <directory>tests/Unit/</directory>
         </testsuite>
     </testsuites>
-    <logging>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-    </logging>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+    </php>
 </phpunit>

--- a/src/Broker/ActiveMq/Options.php
+++ b/src/Broker/ActiveMq/Options.php
@@ -43,16 +43,19 @@ class Options implements ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->options[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->options[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (in_array($offset, $this->extensions, true)) {
@@ -60,6 +63,7 @@ class Options implements ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->options[$offset]);

--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -521,11 +521,7 @@ class Connection
             return $this->onFrame($frame);
         }
 
-        if (!$this->hasDataToRead()) {
-            return false;
-        }
-
-        do {
+        while ($this->hasDataToRead()) {
             $read = @fread($this->connection, $this->maxReadBytes);
             if ($read === false) {
                 throw new ConnectionException(sprintf('Was not possible to read data from stream.'), $this->activeHost);
@@ -546,7 +542,7 @@ class Connection
             if ($frame = $this->parser->nextFrame()) {
                 return $this->onFrame($frame);
             }
-        } while ($this->hasDataToRead());
+        }
 
         return false;
     }
@@ -638,7 +634,7 @@ class Connection
         if ($hasStreamInfo === false) {
             // can return `false` if used in combination with `pcntl_signal` and lead to false errors here
             $error = error_get_last();
-            if ($error && isset($error['message']) && stripos($error['message'], 'interrupted system call') === false) {
+            if ($error && stripos($error['message'], 'interrupted system call') === false) {
                 throw new ConnectionException(
                     'Check failed to determine if the socket is readable.',
                     $this->activeHost
@@ -647,7 +643,7 @@ class Connection
             return null;
         }
 
-        return !empty($read);
+        return $hasStreamInfo > 0;
     }
 
     /**

--- a/src/Protocol/Version.php
+++ b/src/Protocol/Version.php
@@ -69,7 +69,7 @@ class Version
      */
     public function getProtocol($clientId, $default = 'ActiveMQ/5.11.1')
     {
-        $server = trim($this->frame['server']) ?: $default;
+        $server = trim((string) $this->frame['server']) ?: $default;
         $version = $this->getVersion();
         if (stristr($server, 'rabbitmq') !== false) {
             return new RabbitMq($clientId, $version, $server);

--- a/src/States/Meta/SubscriptionList.php
+++ b/src/States/Meta/SubscriptionList.php
@@ -59,6 +59,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return \Iterator|Subscription[]
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->subscriptions);
@@ -69,6 +70,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->subscriptions[$offset]);
@@ -79,6 +81,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return Subscription
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->subscriptions[$offset];
@@ -87,6 +90,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->subscriptions[$offset] = $value;
@@ -95,6 +99,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->subscriptions[$offset]);
@@ -103,6 +108,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->subscriptions);

--- a/src/Transport/Frame.php
+++ b/src/Transport/Frame.php
@@ -212,6 +212,7 @@ class Frame implements ArrayAccess
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->headers[$offset]);
@@ -220,6 +221,7 @@ class Frame implements ArrayAccess
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (isset($this->headers[$offset])) {
@@ -231,6 +233,7 @@ class Frame implements ArrayAccess
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ($value !== null) {
@@ -242,6 +245,7 @@ class Frame implements ArrayAccess
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->headers[$offset]);

--- a/src/Transport/Parser.php
+++ b/src/Transport/Parser.php
@@ -220,6 +220,7 @@ class Parser
         $this->frame = null;
         $this->offset = 0;
         $this->bufferSize = strlen($this->buffer);
+        /** @phpstan-ignore-next-line */
         while ($this->offset < $this->bufferSize) {
             if ($this->mode === self::MODE_HEADER) {
                 $this->skipEmptyLines();

--- a/src/Util/IdGenerator.php
+++ b/src/Util/IdGenerator.php
@@ -31,12 +31,13 @@ class IdGenerator
     public static function generateId()
     {
         while ($rand = rand(1, PHP_INT_MAX)) {
-            if (!in_array($rand, static::$generatedIds, true)) {
-                static::$generatedIds[] = $rand;
+            if (!in_array($rand, self::$generatedIds, true)) {
+                self::$generatedIds[] = $rand;
                 return $rand;
             }
         }
-        throw new RuntimeException('Message Id generation failed.');
+        // This is never hit because the above becomes an infinite loop. Possibly need a release valve.
+        // throw new RuntimeException('Message Id generation failed.');
     }
 
     /**
@@ -46,9 +47,9 @@ class IdGenerator
      */
     public static function releaseId($generatedId)
     {
-        $index = array_search($generatedId, static::$generatedIds, true);
+        $index = array_search($generatedId, self::$generatedIds, true);
         if ($index !== false) {
-            unset(static::$generatedIds[$index]);
+            unset(self::$generatedIds[$index]);
         }
     }
 }

--- a/tests/Functional/Generic/ConnectionTest.php
+++ b/tests/Functional/Generic/ConnectionTest.php
@@ -27,7 +27,7 @@ class ConnectionTest extends TestCase
     {
         /** @var Connection|MockObject $connection */
         $connection = $this->getMockBuilder(Connection::class)
-            ->setMethods(['hasDataToRead', 'connectSocket'])
+            ->onlyMethods(['hasDataToRead', 'connectSocket'])
             ->setConstructorArgs(['tcp://host'])
             ->getMock();
 
@@ -55,7 +55,7 @@ class ConnectionTest extends TestCase
     {
         /** @var \Stomp\Network\Connection|MockObject $connection */
         $connection = $this->getMockBuilder(Connection::class)
-            ->setMethods(['hasDataToRead', 'connectSocket'])
+            ->onlyMethods(['hasDataToRead', 'connectSocket'])
             ->setConstructorArgs(['tcp://host'])
             ->getMock();
 
@@ -83,7 +83,7 @@ class ConnectionTest extends TestCase
     {
         /** @var \Stomp\Network\Connection|MockObject $connection */
         $connection = $this->getMockBuilder(Connection::class)
-            ->setMethods(['connectSocket'])
+            ->onlyMethods(['connectSocket'])
             ->setConstructorArgs(['tcp://host'])
             ->getMock();
 
@@ -107,7 +107,7 @@ class ConnectionTest extends TestCase
     {
         /** @var \Stomp\Network\Connection|MockObject $connection */
         $connection = $this->getMockBuilder(Connection::class)
-            ->setMethods(['isConnected', 'connectSocket'])
+            ->onlyMethods(['isConnected', 'connectSocket'])
             ->setConstructorArgs(['tcp://host'])
             ->getMock();
 

--- a/tests/Unit/Broker/ActiveMq/Mode/ActiveMqModeTest.php
+++ b/tests/Unit/Broker/ActiveMq/Mode/ActiveMqModeTest.php
@@ -27,7 +27,7 @@ class ActiveMqModeTest extends TestCase
     {
         $client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getProtocol'])
+            ->onlyMethods(['getProtocol'])
             ->getMock();
 
         $client->expects($this->any())->method('getProtocol')->willReturn(new RabbitMq('clientid'));

--- a/tests/Unit/Broker/Apollo/Mode/QueueBrowserTest.php
+++ b/tests/Unit/Broker/Apollo/Mode/QueueBrowserTest.php
@@ -26,7 +26,7 @@ class QueueBrowserTest extends TestCase
     {
         $client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getProtocol'])
+            ->onlyMethods(['getProtocol'])
             ->getMock();
         $client->method('getProtocol')->willReturn(new RabbitMq('client-id'));
 

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -119,7 +119,7 @@ class ClientTest extends TestCase
     public function testConnectWillUseConfiguredVersions()
     {
         $connection = $this->getMockBuilder(Connection::class)
-            ->setMethods(['readFrame', 'writeFrame', 'getParser', 'isConnected', 'disconnect'])
+            ->onlyMethods(['readFrame', 'writeFrame', 'getParser', 'isConnected', 'disconnect'])
             ->disableOriginalConstructor()
             ->getMock();
         $connection
@@ -213,7 +213,7 @@ class ClientTest extends TestCase
     protected function getStompWithInjectedMockedConnectionReadResult($readFrameResult)
     {
         $connection = $this->getMockBuilder(Connection::class)
-            ->setMethods(['readFrame', 'writeFrame', 'getParser', 'isConnected', 'disconnect'])
+            ->onlyMethods(['readFrame', 'writeFrame', 'getParser', 'isConnected', 'disconnect'])
             ->disableOriginalConstructor()
             ->getMock();
         $connection
@@ -329,7 +329,7 @@ class ClientTest extends TestCase
     protected function getStompMockWithSendFrameCatcher(&$lastSendFrame, &$lastSyncState)
     {
         $stomp = $this->getMockBuilder(Client::class)
-            ->setMethods(['sendFrame', 'isConnected'])
+            ->onlyMethods(['sendFrame', 'isConnected'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -352,7 +352,7 @@ class ClientTest extends TestCase
     public function testSendFrameWithSyncWillLeadToMessageWithReceiptHeader()
     {
         $connection = $this->getMockBuilder(Connection::class)
-            ->setMethods(['writeFrame', 'readFrame'])
+            ->onlyMethods(['writeFrame', 'readFrame'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -376,7 +376,7 @@ class ClientTest extends TestCase
             );
         $stomp = $this->getMockBuilder(Client::class)
             ->setConstructorArgs([$connection])
-            ->setMethods(['isConnected'])
+            ->onlyMethods(['isConnected'])
             ->getMock();
         $stomp->expects($this->any())->method('isConnected')->willReturn(true);
         /**
@@ -397,7 +397,7 @@ class ClientTest extends TestCase
     public function testWaitForReceiptWillQueueUpFramesWithNoReceiptCommand()
     {
         $connection = $this->getMockBuilder(Connection::class)
-            ->setMethods(['readFrame'])
+            ->onlyMethods(['readFrame'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -424,7 +424,7 @@ class ClientTest extends TestCase
 
         $stomp = $this->getMockBuilder(Client::class)
             ->setConstructorArgs([$connection])
-            ->setMethods(['isConnected'])
+            ->onlyMethods(['isConnected'])
             ->getMock();
         $stomp->expects($this->any())->method('isConnected')->willReturn(true);
         /**
@@ -469,7 +469,7 @@ class ClientTest extends TestCase
     {
         $connection = $this->getMockBuilder(Connection::class)
             ->setConstructorArgs(['tcp://127.0.0.1:'])
-            ->setMethods(['disconnect', 'readFrame', 'writeFrame', 'isConnected'])
+            ->onlyMethods(['disconnect', 'readFrame', 'writeFrame', 'isConnected'])
             ->getMock();
 
         $connection->expects($this->any())->method('isConnected')->willReturn(true);
@@ -504,7 +504,7 @@ class ClientTest extends TestCase
     public function testClientWillAutoConnectOnSendFrame()
     {
         $connection = $this->getMockBuilder(Connection::class)
-            ->setMethods(['connect', 'getParser'])
+            ->onlyMethods(['connect', 'getParser'])
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->once())->method('connect');
@@ -521,7 +521,7 @@ class ClientTest extends TestCase
     public function testClientWillAutoConnectOnGetProtocol()
     {
         $connection = $this->getMockBuilder(Connection::class)
-            ->setMethods(['connect', 'getParser'])
+            ->onlyMethods(['connect', 'getParser'])
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->once())->method('connect');

--- a/tests/Unit/Network/ConnectionTest.php
+++ b/tests/Unit/Network/ConnectionTest.php
@@ -120,7 +120,7 @@ class ConnectionTest extends TestCase
     {
         /** @var Connection|MockObject $connection */
         $connection = $this->getMockBuilder(Connection::class)
-            ->setMethods(['connectSocket'])
+            ->onlyMethods(['connectSocket'])
             ->setConstructorArgs(['failover://(tcp://host1,tcp://host2,tcp://host3)'])
             ->getMock();
 
@@ -182,7 +182,7 @@ class ConnectionTest extends TestCase
         stream_wrapper_register('stompFakeStream', FakeStream::class);
 
         $mock = $this->getMockBuilder(Connection::class)
-            ->setMethods(['getConnection'])
+            ->onlyMethods(['getConnection'])
             ->setConstructorArgs(['stompFakeStream://notInUse'])
             ->getMock();
         $fakeStreamResource = fopen('stompFakeStream://notInUse', 'rw');
@@ -212,7 +212,7 @@ class ConnectionTest extends TestCase
 
 
         $mock = $this->getMockBuilder(Connection::class)
-            ->setMethods(['getConnection'])
+            ->onlyMethods(['getConnection'])
             ->setConstructorArgs(['stompFakeStream://notInUse'])
             ->getMock();
         $fakeStreamResource = fopen('stompFakeStream://notInUse', 'rw');

--- a/tests/Unit/Network/Observer/ConnectionObserverCollectionTest.php
+++ b/tests/Unit/Network/Observer/ConnectionObserverCollectionTest.php
@@ -37,7 +37,7 @@ class ConnectionObserverCollectionTest extends TestCase
         $frameA = new Message('message-a');
         $frameB = new Message('message-b');
         $observerA = $this->getMockBuilder(ConnectionObserver::class)
-            ->setMethods(['sentFrame', 'emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'emptyRead'])
+            ->onlyMethods(['sentFrame', 'emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'emptyRead'])
             ->getMock();
         $observerA->expects($this->exactly(1))->method('sentFrame')->with($frameA);
         $observerA->expects($this->exactly(1))->method('emptyLineReceived');
@@ -46,7 +46,7 @@ class ConnectionObserverCollectionTest extends TestCase
         $observerA->expects($this->exactly(1))->method('receivedFrame')->with($frameB);
 
         $observerB = $this->getMockBuilder(ConnectionObserver::class)
-            ->setMethods(['sentFrame', 'emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'emptyRead'])
+            ->onlyMethods(['sentFrame', 'emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'emptyRead'])
             ->getMock();
         $observerB->expects($this->exactly(1))->method('sentFrame')->with($frameA);
         $observerB->expects($this->exactly(1))->method('emptyLineReceived');

--- a/tests/Unit/Network/Observer/HeartbeatEmitterTest.php
+++ b/tests/Unit/Network/Observer/HeartbeatEmitterTest.php
@@ -45,7 +45,7 @@ class HeartbeatEmitterTest extends TestCase
         parent::setUp();
         $this->connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
-            ->setMethods(['sendAlive', 'getReadTimeout'])
+            ->onlyMethods(['sendAlive', 'getReadTimeout'])
             ->getMock();
         $this->connection->expects($this->any())->method('sendAlive')->willReturnCallback(
             function () {

--- a/tests/Unit/Network/Observer/ServerAliveObserverTest.php
+++ b/tests/Unit/Network/Observer/ServerAliveObserverTest.php
@@ -71,7 +71,7 @@ class ServerAliveObserverTest extends TestCase
     {
         $methods = ['rememberActivity', 'checkDelayed'];
         $instance = $this->getMockBuilder(ServerAliveObserver::class)
-            ->setMethods($methods)
+            ->onlyMethods($methods)
             ->getMock();
         foreach ($methods as $method) {
             $instance->expects(($observerMethod === $method) ? $this->once() : $this->never())

--- a/tests/Unit/SimpleStompTest.php
+++ b/tests/Unit/SimpleStompTest.php
@@ -31,7 +31,7 @@ class SimpleStompTest extends TestCase
 
         $stomp = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['send'])
+            ->onlyMethods(['send'])
             ->getMock();
 
         $stomp->expects($this->once())->method('send')->with($queue, $message);
@@ -53,7 +53,7 @@ class SimpleStompTest extends TestCase
     {
         $stomp = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['sendFrame', 'getProtocol'])
+            ->onlyMethods(['sendFrame', 'getProtocol'])
             ->getMock();
 
         $stomp->expects($this->any())

--- a/tests/Unit/StatefulStompTest.php
+++ b/tests/Unit/StatefulStompTest.php
@@ -82,7 +82,7 @@ class StatefulStompTest extends TestCase
     {
         $client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getProtocol', 'sendFrame', 'readFrame', 'isConnected'])
+            ->onlyMethods(['getProtocol', 'sendFrame', 'readFrame', 'isConnected'])
             ->getMock();
 
         $client->method('getProtocol')->willReturn(new Protocol('stateful-test-client', Version::VERSION_1_2));

--- a/tests/Unit/States/ConsumerStateTest.php
+++ b/tests/Unit/States/ConsumerStateTest.php
@@ -25,7 +25,7 @@ class ConsumerStateTest extends TestCase
     {
         $client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getProtocol', 'sendFrame', 'readFrame'])
+            ->onlyMethods(['getProtocol', 'sendFrame', 'readFrame'])
             ->getMock();
 
         /**

--- a/tests/Unit/Transport/ParserTest.php
+++ b/tests/Unit/Transport/ParserTest.php
@@ -277,7 +277,7 @@ class ParserTest extends TestCase
     public function testParserTriggersObserversHeartBeatAfterFrame()
     {
         $observer = $this->getMockBuilder(ConnectionObserver::class)
-            ->setMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame', 'emptyRead'])
+            ->onlyMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame', 'emptyRead'])
             ->getMock();
         $observer->expects($this->once())->method('emptyLineReceived');
         $observer->expects($this->once())->method('receivedFrame');
@@ -295,7 +295,7 @@ class ParserTest extends TestCase
     public function testParserTriggersObserversOnSingleHeartBeat()
     {
         $observer = $this->getMockBuilder(ConnectionObserver::class)
-            ->setMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame', 'emptyRead'])
+            ->onlyMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame', 'emptyRead'])
             ->getMock();
         $observer->expects($this->once())->method('emptyLineReceived');
         $observer->expects($this->never())->method('receivedFrame');
@@ -311,7 +311,7 @@ class ParserTest extends TestCase
     public function testParserTriggersObserversOnMultipleHeartBeatOnlyOnce()
     {
         $observer = $this->getMockBuilder(ConnectionObserver::class)
-            ->setMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame', 'emptyRead'])
+            ->onlyMethods(['emptyLineReceived', 'emptyBuffer', 'receivedFrame', 'sentFrame', 'emptyRead'])
             ->getMock();
         $observer->expects($this->once())->method('emptyLineReceived');
         $observer->expects($this->never())->method('receivedFrame');


### PR DESCRIPTION
This includes the commits in #166, but also adds some tweaks based on phpstan runs and also adds PHP 8.2 and removes 7.3 from the build matrix.

I have left the 
```yaml
on:
  push:
    branches:
      - '**'
```
for now, I can remove it when you are ready. I can also re-add PHP 7.3 if you want to test it.

See [here](https://github.com/whikloj/stomp-php/actions/runs/5292455065) while it lasts for a test run.

Or you can ignore this and merge @danesteve's  #166 