### PR TITLE
Use return types and phpdoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,14 @@ jobs:
           php-version: '7.4'
           tools: phpstan, composer:v2
 
-      - run: phpstan analyse
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run codesniffer
+        run: composer codestyle
+
+      - name: Run phpstan
+        run: phpstan analyse
 
   tests:
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,8 @@
         "unit-tests": [
             "./vendor/bin/phpunit --no-configuration tests/Unit"
         ],
-        "static-analysis": [
-            "./vendor/bin/phpstan"
+        "phpstan": [
+            "./vendor/bin/phpstan analyse"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
         "php": "^7.3|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "phpstan/phpstan": "^1.10",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {
@@ -39,5 +41,16 @@
         "psr-4": {
             "Stomp\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "codestyle": [
+            "./vendor/bin/phpcs --extensions=php --standard=PSR2 --ignore=vendor src tests"
+        ],
+        "unit-tests": [
+            "./vendor/bin/phpunit --no-configuration tests/Unit"
+        ],
+        "static-analysis": [
+            "./vendor/bin/phpstan"
+        ]
     }
 }

--- a/src/Broker/ActiveMq/ActiveMq.php
+++ b/src/Broker/ActiveMq/ActiveMq.php
@@ -36,19 +36,19 @@ class ActiveMq extends Protocol
      * ActiveMq subscribe frame.
      *
      * @param string $destination
-     * @param string $subscriptionId
+     * @param string|null $subscriptionId
      * @param string $ack
-     * @param string $selector
-     * @param boolean|false $durable durable subscription
+     * @param string|null $selector
+     * @param boolean $durable durable subscription
      * @return Frame
      */
     public function getSubscribeFrame(
-        $destination,
-        $subscriptionId = null,
-        $ack = 'auto',
-        $selector = null,
-        $durable = false
-    ) {
+        string $destination,
+        ?string $subscriptionId = null,
+        string $ack = 'auto',
+        ?string $selector = null,
+        bool $durable = false
+    ): Frame {
         $frame = parent::getSubscribeFrame($destination, $subscriptionId, $ack, $selector);
         $frame['activemq.prefetchSize'] = $this->prefetchSize;
         if ($durable) {
@@ -61,13 +61,16 @@ class ActiveMq extends Protocol
     /**
      * ActiveMq unsubscribe frame.
      *
-     * @param string $destination
-     * @param string $subscriptionId
-     * @param bool|false $durable
+     * @param string $destination The destination to unsubscribe from.
+     * @param string|null $subscriptionId The subscription id to unsubscribe from.
+     * @param bool $durable Whether this was a durable subscription.
      * @return Frame
      */
-    public function getUnsubscribeFrame($destination, $subscriptionId = null, $durable = false)
-    {
+    public function getUnsubscribeFrame(
+        string $destination,
+        ?string $subscriptionId = null,
+        bool $durable = false
+    ): Frame {
         $frame = parent::getUnsubscribeFrame($destination, $subscriptionId);
         if ($durable) {
             $frame['activemq.subscriptionName'] = $this->getClientId();
@@ -79,7 +82,7 @@ class ActiveMq extends Protocol
     /**
      * @inheritdoc
      */
-    public function getAckFrame(Frame $frame, $transactionId = null)
+    public function getAckFrame(Frame $frame, ?string $transactionId = null): Frame
     {
         $ack = $this->createFrame('ACK');
         $ack['transaction'] = $transactionId;
@@ -97,7 +100,7 @@ class ActiveMq extends Protocol
     /**
      * @inheritdoc
      */
-    public function getNackFrame(Frame $frame, $transactionId = null, $requeue = null)
+    public function getNackFrame(Frame $frame, ?string $transactionId = null, ?bool $requeue = null): Frame
     {
         if ($requeue !== null) {
             throw new \LogicException(
@@ -123,7 +126,7 @@ class ActiveMq extends Protocol
      *
      * @return int
      */
-    public function getPrefetchSize()
+    public function getPrefetchSize(): int
     {
         return $this->prefetchSize;
     }
@@ -134,7 +137,7 @@ class ActiveMq extends Protocol
      * @param int $prefetchSize
      * @return ActiveMq
      */
-    public function setPrefetchSize($prefetchSize)
+    public function setPrefetchSize(int $prefetchSize): self
     {
         $this->prefetchSize = $prefetchSize;
         return $this;

--- a/src/Broker/ActiveMq/ActiveMq.php
+++ b/src/Broker/ActiveMq/ActiveMq.php
@@ -35,12 +35,12 @@ class ActiveMq extends Protocol
     /**
      * ActiveMq subscribe frame.
      *
-     * @param string $destination
-     * @param string|null $subscriptionId
-     * @param string $ack
-     * @param string|null $selector
+     * @param string $destination The destination to subscribe to.
+     * @param string|null $subscriptionId A subscription id.
+     * @param string $ack The ACK selection.
+     * @param string|null $selector An Sql 92 selector.
      * @param boolean $durable durable subscription
-     * @return Frame
+     * @return Frame The SUBSCRIBE frame.
      */
     public function getSubscribeFrame(
         string $destination,
@@ -64,7 +64,7 @@ class ActiveMq extends Protocol
      * @param string $destination The destination to unsubscribe from.
      * @param string|null $subscriptionId The subscription id to unsubscribe from.
      * @param bool $durable Whether this was a durable subscription.
-     * @return Frame
+     * @return Frame The UNSUBSCRIBE frame.
      */
     public function getUnsubscribeFrame(
         string $destination,
@@ -81,6 +81,8 @@ class ActiveMq extends Protocol
 
     /**
      * @inheritdoc
+     *
+     * @note ActiveMq seems to allow 'ack' header for ack messages. This is not spec compliant.
      */
     public function getAckFrame(Frame $frame, ?string $transactionId = null): Frame
     {
@@ -99,6 +101,8 @@ class ActiveMq extends Protocol
 
     /**
      * @inheritdoc
+     *
+     * @note ActiveMq seems to allow 'ack' header for nack messages. This is not spec compliant.
      */
     public function getNackFrame(Frame $frame, ?string $transactionId = null, ?bool $requeue = null): Frame
     {

--- a/src/Broker/ActiveMq/Mode/ActiveMqMode.php
+++ b/src/Broker/ActiveMq/Mode/ActiveMqMode.php
@@ -47,7 +47,7 @@ abstract class ActiveMqMode
      * @return ActiveMq
      * @throws \Stomp\Broker\Exception\UnsupportedBrokerException
      */
-    protected function getProtocol()
+    protected function getProtocol(): ActiveMq
     {
         $protocol = $this->client->getProtocol();
         if (!$protocol instanceof ActiveMq) {
@@ -60,7 +60,7 @@ abstract class ActiveMqMode
     /**
      * @return Options
      */
-    public function getOptions()
+    public function getOptions(): Options
     {
         return $this->options;
     }
@@ -69,7 +69,7 @@ abstract class ActiveMqMode
      * @param Options $options
      * @return ActiveMqMode
      */
-    public function setOptions(Options $options)
+    public function setOptions(Options $options): self
     {
         $this->options = $options;
         return $this;

--- a/src/Broker/ActiveMq/Mode/DurableSubscription.php
+++ b/src/Broker/ActiveMq/Mode/DurableSubscription.php
@@ -42,8 +42,13 @@ class DurableSubscription extends ActiveMqMode
      * @param string $subscriptionId
      * @throws StompException
      */
-    public function __construct(Client $client, $topic, $selector = null, $ack = 'auto', $subscriptionId = null)
-    {
+    public function __construct(
+        Client $client,
+        string $topic,
+        ?string $selector = null,
+        string $ack = 'auto',
+        ?string $subscriptionId = null
+    ) {
         parent::__construct($client);
         if (!$client->getClientId()) {
             throw new StompException('Client must have been configured to use a specific clientId!');
@@ -158,7 +163,7 @@ class DurableSubscription extends ActiveMqMode
      *
      * @return Subscription
      */
-    public function getSubscription()
+    public function getSubscription(): Subscription
     {
         return $this->subscription;
     }
@@ -168,7 +173,7 @@ class DurableSubscription extends ActiveMqMode
      *
      * @return boolean
      */
-    public function isActive()
+    public function isActive(): bool
     {
         return $this->active;
     }

--- a/src/Broker/ActiveMq/Options.php
+++ b/src/Broker/ActiveMq/Options.php
@@ -43,76 +43,126 @@ class Options implements ArrayAccess
         }
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    /**
+     * @inheritdoc
+     */
+    public function offsetExists($offset): bool
     {
         return isset($this->options[$offset]);
     }
 
+
+    /**
+     * @inheritdoc
+     */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->options[$offset];
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    /**
+     * @inheritdoc
+     */
+    public function offsetSet($offset, $value): void
     {
         if (in_array($offset, $this->extensions, true)) {
             $this->options[$offset] = $value;
         }
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    /**
+     * @inheritdoc
+     */
+    public function offsetUnset($offset): void
     {
         unset($this->options[$offset]);
     }
 
-    public function getOptions()
+    /**
+     * @return array The options.
+     */
+    public function getOptions(): array
     {
         return $this->options;
     }
 
 
-    public function activateRetroactive()
+    /**
+     * Activate retroactive option.
+     *
+     * @return $this
+     */
+    public function activateRetroactive(): self
     {
         $this['activemq.retroactive'] = 'true';
         return $this;
     }
-    public function activateExclusive()
+
+    /**
+     * Active exclusive option.
+     *
+     * @return $this
+     */
+    public function activateExclusive(): self
     {
         $this['activemq.exclusive'] = 'true';
         return $this;
     }
 
-    public function activateDispatchAsync()
+    /**
+     * Active dispatchAsync option.
+     *
+     * @return $this
+     */
+    public function activateDispatchAsync(): self
     {
         $this['activemq.dispatchAsync'] = 'true';
         return $this;
     }
 
-    public function setPriority($priority)
+    /**
+     * Set the priority.
+     *
+     * @param $priority mixed The priority.
+     * @return $this
+     */
+    public function setPriority($priority): self
     {
         $this['activemq.priority'] = $priority;
         return $this;
     }
 
-
-    public function setPrefetchSize($size)
+    /**
+     * Set the prefetch size.
+     *
+     * @param $size mixed The prefetch size to set.
+     * @return $this
+     */
+    public function setPrefetchSize($size): self
     {
         $this['activemq.prefetchSize'] = max($size, 1);
         return $this;
     }
 
-
-    public function activateNoLocal()
+    /**
+     * Activate the noLocal option.
+     *
+     * @return $this
+     */
+    public function activateNoLocal(): self
     {
         $this['activemq.noLocal'] = 'true';
         return $this;
     }
 
-    public function setMaximumPendingLimit($limit)
+    /**
+     * Set the maximum pending limit option.
+     *
+     * @param $limit mixed The max pending limit.
+     * @return $this
+     */
+    public function setMaximumPendingLimit($limit): self
     {
         $this['activemq.maximumPendingMessageLimit'] = $limit;
         return $this;

--- a/src/Broker/Apollo/Apollo.php
+++ b/src/Broker/Apollo/Apollo.php
@@ -68,24 +68,6 @@ class Apollo extends Protocol
     /**
      * @inheritdoc
      */
-    public function getAckFrame(Frame $frame, ?string $transactionId = null): Frame
-    {
-        $ack = $this->createFrame('ACK');
-        $ack['transaction'] = $transactionId;
-        if ($this->hasVersion(Version::VERSION_1_2)) {
-            $ack['id'] = $frame['ack'] ?: $frame->getMessageId();
-        } else {
-            $ack['message-id'] = $frame['ack'] ?: $frame->getMessageId();
-            if ($this->hasVersion(Version::VERSION_1_1)) {
-                $ack['subscription'] = $frame['subscription'];
-            }
-        }
-        return $ack;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getNackFrame(Frame $frame, ?string $transactionId = null, ?bool $requeue = null): Frame
     {
         if ($requeue !== null) {
@@ -94,9 +76,13 @@ class Apollo extends Protocol
         $nack = $this->createFrame('NACK');
         $nack['transaction'] = $transactionId;
         if ($this->hasVersion(Version::VERSION_1_2)) {
-            $nack['id'] = $frame['ack'] ?: $frame->getMessageId();
+            $nack['id'] = $frame['id'] ?: $frame->getMessageId();
         } else {
-            $nack['message-id'] = $frame['ack'] ?: $frame->getMessageId();
+            if (isset($frame['ack'])) {
+                $nack['message-id'] = $frame['ack'];
+            } else {
+                $nack['message-id'] = $frame['message-id'] ?: $frame->getMessageId();
+            }
             if ($this->hasVersion(Version::VERSION_1_1)) {
                 $nack['subscription'] = $frame['subscription'];
             }

--- a/src/Broker/Apollo/Apollo.php
+++ b/src/Broker/Apollo/Apollo.php
@@ -25,19 +25,19 @@ class Apollo extends Protocol
      * Apollo subscribe frame.
      *
      * @param string $destination
-     * @param string $subscriptionId
+     * @param string|null $subscriptionId
      * @param string $ack
-     * @param string $selector
+     * @param string|null $selector
      * @param boolean $durable durable subscription
      * @return \Stomp\Transport\Frame
      */
     public function getSubscribeFrame(
-        $destination,
-        $subscriptionId = null,
-        $ack = 'auto',
-        $selector = null,
-        $durable = false
-    ) {
+        string $destination,
+        ?string $subscriptionId = null,
+        string $ack = 'auto',
+        ?string $selector = null,
+        bool $durable = false
+    ): Frame {
         $frame = parent::getSubscribeFrame($destination, $subscriptionId, $ack, $selector);
         if ($this->hasClientId() && $durable) {
             $frame['persistent'] = 'true';
@@ -49,12 +49,15 @@ class Apollo extends Protocol
      * Apollo unsubscribe frame.
      *
      * @param string $destination
-     * @param string $subscriptionId
+     * @param string|null $subscriptionId
      * @param bool|false $durable
      * @return \Stomp\Transport\Frame
      */
-    public function getUnsubscribeFrame($destination, $subscriptionId = null, $durable = false)
-    {
+    public function getUnsubscribeFrame(
+        string $destination,
+        ?string $subscriptionId = null,
+        bool $durable = false
+    ): Frame {
         $frame = parent::getUnsubscribeFrame($destination, $subscriptionId);
         if ($durable) {
             $frame['persistent'] = 'true';
@@ -65,7 +68,7 @@ class Apollo extends Protocol
     /**
      * @inheritdoc
      */
-    public function getAckFrame(Frame $frame, $transactionId = null)
+    public function getAckFrame(Frame $frame, ?string $transactionId = null): Frame
     {
         $ack = $this->createFrame('ACK');
         $ack['transaction'] = $transactionId;
@@ -83,7 +86,7 @@ class Apollo extends Protocol
     /**
      * @inheritdoc
      */
-    public function getNackFrame(Frame $frame, $transactionId = null, $requeue = null)
+    public function getNackFrame(Frame $frame, ?string $transactionId = null, ?bool $requeue = null): Frame
     {
         if ($requeue !== null) {
             throw new \LogicException('requeue header not supported');

--- a/src/Broker/Apollo/Apollo.php
+++ b/src/Broker/Apollo/Apollo.php
@@ -24,12 +24,12 @@ class Apollo extends Protocol
     /**
      * Apollo subscribe frame.
      *
-     * @param string $destination
-     * @param string|null $subscriptionId
-     * @param string $ack
-     * @param string|null $selector
+     * @param string $destination The destination to subscribe to.
+     * @param string|null $subscriptionId A subscription id.
+     * @param string $ack The ACK selection.
+     * @param string|null $selector An Sql 92 selector.
      * @param boolean $durable durable subscription
-     * @return \Stomp\Transport\Frame
+     * @return \Stomp\Transport\Frame The SUBSCRIBE frame
      */
     public function getSubscribeFrame(
         string $destination,
@@ -48,10 +48,10 @@ class Apollo extends Protocol
     /**
      * Apollo unsubscribe frame.
      *
-     * @param string $destination
-     * @param string|null $subscriptionId
-     * @param bool|false $durable
-     * @return \Stomp\Transport\Frame
+     * @param string $destination The destination to unsubscribe from.
+     * @param string|null $subscriptionId The subscription id to unsubscribe from.
+     * @param bool $durable Whether this was a durable subscription.
+     * @return \Stomp\Transport\Frame The UNSUBSCRIBE frame
      */
     public function getUnsubscribeFrame(
         string $destination,
@@ -68,7 +68,7 @@ class Apollo extends Protocol
     /**
      * @inheritdoc
      *
-     * TODO: Apollo uses some 'ack' header for ack and nack messages. This is not spec compliant.
+     * @note Apollo seems to allow 'ack' header for ack messages. This is not spec compliant.
      */
     public function getAckFrame(Frame $frame, string $transactionId = null): Frame
     {
@@ -88,7 +88,7 @@ class Apollo extends Protocol
     /**
      * @inheritdoc
      *
-     * TODO: Apollo uses some 'ack' header for ack and nack messages. This is not spec compliant.
+     * @note Apollo seems to allow 'ack' header for nack messages. This is not spec compliant.
      */
     public function getNackFrame(Frame $frame, ?string $transactionId = null, ?bool $requeue = null): Frame
     {

--- a/src/Broker/Apollo/Apollo.php
+++ b/src/Broker/Apollo/Apollo.php
@@ -67,6 +67,28 @@ class Apollo extends Protocol
 
     /**
      * @inheritdoc
+     *
+     * TODO: Apollo uses some 'ack' header for ack and nack messages. This is not spec compliant.
+     */
+    public function getAckFrame(Frame $frame, string $transactionId = null): Frame
+    {
+        $ack = $this->createFrame('ACK');
+        $ack['transaction'] = $transactionId;
+        if ($this->hasVersion(Version::VERSION_1_2)) {
+            $ack['id'] = $frame['ack'] ?: $frame->getMessageId();
+        } else {
+            $ack['message-id'] = $frame['ack'] ?: $frame->getMessageId();
+            if ($this->hasVersion(Version::VERSION_1_1)) {
+                $ack['subscription'] = $frame['subscription'];
+            }
+        }
+        return $ack;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * TODO: Apollo uses some 'ack' header for ack and nack messages. This is not spec compliant.
      */
     public function getNackFrame(Frame $frame, ?string $transactionId = null, ?bool $requeue = null): Frame
     {
@@ -76,13 +98,9 @@ class Apollo extends Protocol
         $nack = $this->createFrame('NACK');
         $nack['transaction'] = $transactionId;
         if ($this->hasVersion(Version::VERSION_1_2)) {
-            $nack['id'] = $frame['id'] ?: $frame->getMessageId();
+            $nack['id'] = $frame['ack'] ?: $frame->getMessageId();
         } else {
-            if (isset($frame['ack'])) {
-                $nack['message-id'] = $frame['ack'];
-            } else {
-                $nack['message-id'] = $frame['message-id'] ?: $frame->getMessageId();
-            }
+            $nack['message-id'] = $frame['ack'] ?: $frame->getMessageId();
             if ($this->hasVersion(Version::VERSION_1_1)) {
                 $nack['subscription'] = $frame['subscription'];
             }

--- a/src/Broker/Apollo/Mode/QueueBrowser.php
+++ b/src/Broker/Apollo/Mode/QueueBrowser.php
@@ -56,9 +56,8 @@ class QueueBrowser
      * @param string $destination
      * @param bool $stopOnEnd
      */
-    public function __construct(Client $client, $destination, $stopOnEnd = true)
+    public function __construct(Client $client, string $destination, bool $stopOnEnd = true)
     {
-        $this->stopOnEnd = $stopOnEnd;
         $this->client = $client;
         $this->stopOnEnd = $stopOnEnd;
         $this->subscription = new Subscription($destination, null, 'auto', IdGenerator::generateId());
@@ -69,7 +68,7 @@ class QueueBrowser
      * @return Apollo
      * @throws UnsupportedBrokerException
      */
-    final protected function getProtocol()
+    final protected function getProtocol(): Apollo
     {
         $protocol = $this->client->getProtocol();
         if (!$protocol instanceof Apollo) {
@@ -83,7 +82,7 @@ class QueueBrowser
      *
      * @return array
      */
-    protected function getHeader()
+    protected function getHeader(): array
     {
         return [
             'browser' => 'true',
@@ -135,7 +134,7 @@ class QueueBrowser
     /**
      * Read next message.
      *
-     * @return bool|false|\Stomp\Transport\Frame
+     * @return bool|\Stomp\Transport\Frame
      */
     public function read()
     {
@@ -156,7 +155,7 @@ class QueueBrowser
      *
      * @return boolean
      */
-    public function hasReachedEnd()
+    public function hasReachedEnd(): bool
     {
         return $this->reachedEnd;
     }
@@ -166,7 +165,7 @@ class QueueBrowser
      *
      * @return boolean
      */
-    public function isActive()
+    public function isActive(): bool
     {
         return $this->active;
     }
@@ -176,7 +175,7 @@ class QueueBrowser
      *
      * @return Subscription
      */
-    public function getSubscription()
+    public function getSubscription(): Subscription
     {
         return $this->subscription;
     }

--- a/src/Broker/Apollo/Mode/SequenceQueueBrowser.php
+++ b/src/Broker/Apollo/Mode/SequenceQueueBrowser.php
@@ -50,8 +50,12 @@ class SequenceQueueBrowser extends QueueBrowser
      * @param int $startAt
      * @param bool $stopOnEnd
      */
-    public function __construct(Client $client, $destination, $startAt = self::START_HEAD, $stopOnEnd = true)
-    {
+    public function __construct(
+        Client $client,
+        string $destination,
+        int $startAt = self::START_HEAD,
+        bool $stopOnEnd = true
+    ) {
         $this->startAt = $startAt;
         parent::__construct($client, $destination, $stopOnEnd);
     }
@@ -59,7 +63,7 @@ class SequenceQueueBrowser extends QueueBrowser
     /**
      * @inheritdoc
      */
-    protected function getHeader()
+    protected function getHeader(): array
     {
         return parent::getHeader() + ['include-seq' => 'seq', 'from-seq' => $this->startAt];
     }
@@ -80,7 +84,7 @@ class SequenceQueueBrowser extends QueueBrowser
      *
      * @return null|int
      */
-    public function getSeq()
+    public function getSeq(): ?int
     {
         return $this->seq;
     }

--- a/src/Broker/Exception/UnsupportedBrokerException.php
+++ b/src/Broker/Exception/UnsupportedBrokerException.php
@@ -26,7 +26,7 @@ class UnsupportedBrokerException extends StompException
      * @param Protocol $detectedProtocol
      * @param string $expectedProtocol
      */
-    public function __construct(Protocol $detectedProtocol, $expectedProtocol)
+    public function __construct(Protocol $detectedProtocol, string $expectedProtocol)
     {
         parent::__construct(
             sprintf('The current broker (%s) is no %s.', get_class($detectedProtocol), $expectedProtocol)

--- a/src/Broker/OpenMq/OpenMq.php
+++ b/src/Broker/OpenMq/OpenMq.php
@@ -26,17 +26,7 @@ class OpenMq extends Protocol
      */
     public function getAckFrame(Frame $frame, ?string $transactionId = null): Frame
     {
-        $ack = $this->createFrame('ACK');
-        $ack['transaction'] = $transactionId;
-        if ($this->hasVersion(Version::VERSION_1_2)) {
-            if (isset($frame['ack'])) {
-                $ack['id'] = $frame['ack'];
-            } else {
-                $ack['id'] = $frame->getMessageId();
-            }
-        } else {
-            $ack['message-id'] = $frame->getMessageId();
-        }
+        $ack = parent::getAckFrame($frame, $transactionId);
         // spec quote: "ACK should always specify a "subscription" header for the subscription id
         //              that the message to be acked was delivered to ."
         // see https://mq.java.net/4.4-content/stomp-funcspec.html

--- a/src/Broker/OpenMq/OpenMq.php
+++ b/src/Broker/OpenMq/OpenMq.php
@@ -26,7 +26,17 @@ class OpenMq extends Protocol
      */
     public function getAckFrame(Frame $frame, ?string $transactionId = null): Frame
     {
-        $ack = parent::getAckFrame($frame, $transactionId);
+        $ack = $this->createFrame('ACK');
+        $ack['transaction'] = $transactionId;
+        if ($this->hasVersion(Version::VERSION_1_2)) {
+            if (isset($frame['ack'])) {
+                $ack['id'] = $frame['ack'];
+            } else {
+                $ack['id'] = $frame->getMessageId();
+            }
+        } else {
+            $ack['message-id'] = $frame->getMessageId();
+        }
         // spec quote: "ACK should always specify a "subscription" header for the subscription id
         //              that the message to be acked was delivered to ."
         // see https://mq.java.net/4.4-content/stomp-funcspec.html

--- a/src/Broker/OpenMq/OpenMq.php
+++ b/src/Broker/OpenMq/OpenMq.php
@@ -24,7 +24,7 @@ class OpenMq extends Protocol
     /**
      * @inheritdoc
      */
-    public function getAckFrame(Frame $frame, $transactionId = null)
+    public function getAckFrame(Frame $frame, ?string $transactionId = null): Frame
     {
         $ack = $this->createFrame('ACK');
         $ack['transaction'] = $transactionId;

--- a/src/Broker/RabbitMq/RabbitMq.php
+++ b/src/Broker/RabbitMq/RabbitMq.php
@@ -39,19 +39,19 @@ class RabbitMq extends Protocol
      * RabbitMq subscribe frame.
      *
      * @param string $destination
-     * @param string $subscriptionId
+     * @param string|null $subscriptionId
      * @param string $ack
-     * @param string $selector
+     * @param string|null $selector
      * @param boolean|false $durable durable subscription
      * @return Frame
      */
     public function getSubscribeFrame(
-        $destination,
-        $subscriptionId = null,
-        $ack = 'auto',
-        $selector = null,
-        $durable = false
-    ) {
+        string $destination,
+        ?string $subscriptionId = null,
+        string $ack = 'auto',
+        ?string $selector = null,
+        bool $durable = false
+    ): Frame {
         $frame = parent::getSubscribeFrame($destination, $subscriptionId, $ack, $selector);
         $frame['prefetch-count'] = $this->prefetchCount;
         if ($durable) {
@@ -64,12 +64,15 @@ class RabbitMq extends Protocol
      * RabbitMq unsubscribe frame.
      *
      * @param string $destination
-     * @param string $subscriptionId
+     * @param string|null $subscriptionId
      * @param bool|false $durable
      * @return \Stomp\Transport\Frame
      */
-    public function getUnsubscribeFrame($destination, $subscriptionId = null, $durable = false)
-    {
+    public function getUnsubscribeFrame(
+        string $destination,
+        ?string $subscriptionId = null,
+        bool $durable = false
+    ): Frame {
         $frame = parent::getUnsubscribeFrame($destination, $subscriptionId);
         if ($durable) {
             $frame['persistent'] = 'true';
@@ -83,7 +86,7 @@ class RabbitMq extends Protocol
      *
      * @return int
      */
-    public function getPrefetchCount()
+    public function getPrefetchCount(): int
     {
         return $this->prefetchCount;
     }
@@ -93,7 +96,7 @@ class RabbitMq extends Protocol
      *
      * @param int $prefetchCount
      */
-    public function setPrefetchCount($prefetchCount)
+    public function setPrefetchCount(int $prefetchCount)
     {
         $this->prefetchCount = $prefetchCount;
     }
@@ -103,12 +106,12 @@ class RabbitMq extends Protocol
      * Get message not acknowledge frame.
      *
      * @param \Stomp\Transport\Frame $frame
-     * @param string $transactionId
-     * @param bool $requeue Requeue header supported on RabbitMQ >= 3.4, ignored in prior versions
+     * @param string|null $transactionId
+     * @param bool|null $requeue Requeue header supported on RabbitMQ >= 3.4, ignored in prior versions
      * @return \Stomp\Transport\Frame
      * @throws StompException
      */
-    public function getNackFrame(Frame $frame, $transactionId = null, $requeue = null)
+    public function getNackFrame(Frame $frame, ?string $transactionId = null, ?bool $requeue = null): Frame
     {
         if ($this->getVersion() === Version::VERSION_1_0) {
             throw new StompException('Stomp Version 1.0 has no support for NACK Frames.');

--- a/src/Broker/RabbitMq/RabbitMq.php
+++ b/src/Broker/RabbitMq/RabbitMq.php
@@ -38,12 +38,12 @@ class RabbitMq extends Protocol
     /**
      * RabbitMq subscribe frame.
      *
-     * @param string $destination
-     * @param string|null $subscriptionId
-     * @param string $ack
-     * @param string|null $selector
+     * @param string $destination The destination to subscribe to.
+     * @param string|null $subscriptionId A subscription id.
+     * @param string $ack The ACK selection.
+     * @param string|null $selector An Sql 92 selector.
      * @param boolean|false $durable durable subscription
-     * @return Frame
+     * @return Frame The SUBSCRIBE frame
      */
     public function getSubscribeFrame(
         string $destination,
@@ -63,10 +63,10 @@ class RabbitMq extends Protocol
     /**
      * RabbitMq unsubscribe frame.
      *
-     * @param string $destination
-     * @param string|null $subscriptionId
-     * @param bool|false $durable
-     * @return \Stomp\Transport\Frame
+     * @param string $destination The destination to unsubscribe from.
+     * @param string|null $subscriptionId The subscription id to unsubscribe from.
+     * @param bool $durable Whether this was a durable subscription.
+     * @return \Stomp\Transport\Frame The UNSUBSCRIBE frame
      */
     public function getUnsubscribeFrame(
         string $destination,
@@ -105,32 +105,18 @@ class RabbitMq extends Protocol
     /**
      * Get message not acknowledge frame.
      *
-     * @param \Stomp\Transport\Frame $frame
-     * @param string|null $transactionId
+     * @param \Stomp\Transport\Frame $frame The frame to generate a NACK frame for.
+     * @param string|null $transactionId A transaction ID (if applicable)
      * @param bool|null $requeue Requeue header supported on RabbitMQ >= 3.4, ignored in prior versions
-     * @return \Stomp\Transport\Frame
+     * @return \Stomp\Transport\Frame The NACK frame
      * @throws StompException
      */
     public function getNackFrame(Frame $frame, ?string $transactionId = null, ?bool $requeue = null): Frame
     {
-        if ($this->getVersion() === Version::VERSION_1_0) {
-            throw new StompException('Stomp Version 1.0 has no support for NACK Frames.');
-        }
-        $nack = $this->createFrame('NACK');
+        $nack = parent::getNackFrame($frame, $transactionId);
         if ($requeue !== null) {
             $nack->addHeaders(['requeue' => $requeue ? 'true' : 'false']);
         }
-        $nack['transaction'] = $transactionId;
-        if ($this->hasVersion(Version::VERSION_1_2)) {
-            $nack['id'] = $frame->getMessageId();
-        } else {
-            $nack['message-id'] = $frame->getMessageId();
-            if ($this->hasVersion(Version::VERSION_1_1)) {
-                $nack['subscription'] = $frame['subscription'];
-            }
-        }
-
-        $nack['message-id'] = $frame->getMessageId();
         return $nack;
     }
 }

--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -157,7 +157,7 @@ class Connection
      * @param array $context stream context
      * @throws ConnectionException
      */
-    public function __construct($brokerUri, $connectionTimeout = 1, array $context = [])
+    public function __construct(string $brokerUri, int $connectionTimeout = 1, array $context = [])
     {
         $this->parser = new Parser();
         $this->observers = new ConnectionObserverCollection();
@@ -199,7 +199,7 @@ class Connection
      *
      * @param callable|null $waitCallback
      */
-    public function setWaitCallback($waitCallback)
+    public function setWaitCallback(?callable $waitCallback)
     {
         if ($waitCallback !== null) {
             if (!is_callable($waitCallback)) {
@@ -214,7 +214,7 @@ class Connection
      *
      * @return int
      */
-    public function getConnectTimeout()
+    public function getConnectTimeout(): ?int
     {
         return $this->connectTimeout;
     }
@@ -224,7 +224,7 @@ class Connection
      *
      * @return ConnectionObserverCollection
      */
-    public function getObservers()
+    public function getObservers(): ConnectionObserverCollection
     {
         return $this->observers;
     }
@@ -236,7 +236,7 @@ class Connection
      * @return void
      * @throws ConnectionException
      */
-    private function parseUrl($url)
+    private function parseUrl(string $url)
     {
         $parsed = parse_url($url);
         if ($parsed === false) {
@@ -252,7 +252,7 @@ class Connection
      * @param integer $microseconds microseconds (1μs = 0.000001s, ex. 500ms = 500000)
      * @return void
      */
-    public function setReadTimeout($seconds, $microseconds = 0)
+    public function setReadTimeout(int $seconds, int $microseconds = 0)
     {
         $this->readTimeout[0] = $seconds;
         $this->readTimeout[1] = $microseconds;
@@ -265,7 +265,7 @@ class Connection
      *
      * @return array
      */
-    public function getReadTimeout()
+    public function getReadTimeout(): array
     {
         return $this->readTimeout;
     }
@@ -275,7 +275,7 @@ class Connection
      *
      * @param int $writeTimeout seconds
      */
-    public function setWriteTimeout($writeTimeout)
+    public function setWriteTimeout(int $writeTimeout)
     {
         $this->writeTimeout = $writeTimeout;
     }
@@ -298,7 +298,7 @@ class Connection
      *
      * @param int $maxWriteBytes bytes
      */
-    public function setMaxWriteBytes($maxWriteBytes)
+    public function setMaxWriteBytes(int $maxWriteBytes)
     {
         $this->maxWriteBytes = $maxWriteBytes;
     }
@@ -310,7 +310,7 @@ class Connection
      *
      * @param int $maxReadBytes bytes
      */
-    public function setMaxReadBytes($maxReadBytes)
+    public function setMaxReadBytes(int $maxReadBytes)
     {
         $this->maxReadBytes = $maxReadBytes;
     }
@@ -321,7 +321,7 @@ class Connection
      * @return boolean
      * @throws ConnectionException
      */
-    public function connect()
+    public function connect(): bool
     {
         if (!$this->isConnected()) {
             $this->connection = $this->getConnection();
@@ -332,7 +332,7 @@ class Connection
     /**
      * @param boolean $persistentConnection
      */
-    public function setPersistentConnection($persistentConnection)
+    public function setPersistentConnection(bool $persistentConnection)
     {
         $this->persistentConnection = $persistentConnection;
     }
@@ -363,7 +363,7 @@ class Connection
      *
      * @return array
      */
-    protected function getHostList()
+    protected function getHostList(): array
     {
         $hosts = array_values($this->hosts);
         if ($this->shouldRandomizeHosts()) {
@@ -380,7 +380,7 @@ class Connection
      * @return bool
      *   Whether the broker hosts should be shuffled in random order.
      */
-    protected function shouldRandomizeHosts()
+    protected function shouldRandomizeHosts(): bool
     {
         return filter_var($this->params['randomize'], FILTER_VALIDATE_BOOLEAN);
     }
@@ -430,7 +430,7 @@ class Connection
      *
      * @return boolean
      */
-    public function isConnected()
+    public function isConnected(): bool
     {
         return ($this->connection && is_resource($this->connection));
     }
@@ -457,7 +457,7 @@ class Connection
      * @return boolean
      * @throws ConnectionException
      */
-    public function writeFrame(Frame $stompFrame)
+    public function writeFrame(Frame $stompFrame): ?bool
     {
         if (!$this->isConnected()) {
             throw new ConnectionException('Not connected to any server.', $this->activeHost);
@@ -474,7 +474,7 @@ class Connection
      * @param float $timeout in seconds, supporting fractions
      * @throws ConnectionException
      */
-    private function writeData($stompFrame, $timeout)
+    private function writeData($stompFrame, float $timeout)
     {
         $data = (string) $stompFrame;
         $offset = 0;
@@ -554,7 +554,7 @@ class Connection
      * @return Frame
      * @throws ErrorFrameException
      */
-    private function onFrame(Frame $frame)
+    private function onFrame(Frame $frame): Frame
     {
         if ($frame->isErrorFrame()) {
             throw new ErrorFrameException($frame);
@@ -571,7 +571,7 @@ class Connection
      * @throws ConnectionException
      * @see Connection::setReadTimeout()
      */
-    public function hasDataToRead()
+    public function hasDataToRead(): bool
     {
         if (!$this->isConnected()) {
             throw new ConnectionException('Not connected to any server.', $this->activeHost);
@@ -594,7 +594,7 @@ class Connection
      * @return bool
      * @throws ConnectionException
      */
-    private function connectionHasDataToRead($timeoutSec, $timeoutMicros)
+    private function connectionHasDataToRead(int $timeoutSec, int $timeoutMicros): bool
     {
         $timeout = microtime(true) + $timeoutSec + ($timeoutMicros ? $timeoutMicros / 1000000 : 0);
         while (($hasData = $this->isDataOnStream()) === false) {
@@ -624,7 +624,7 @@ class Connection
      * @return bool|null
      * @throws ConnectionException
      */
-    private function isDataOnStream()
+    private function isDataOnStream(): ?bool
     {
         $read = [$this->connection];
         $write = null;
@@ -651,7 +651,7 @@ class Connection
      *
      * @return Parser
      */
-    public function getParser()
+    public function getParser(): Parser
     {
         return $this->parser;
     }
@@ -661,7 +661,7 @@ class Connection
      *
      * @return String
      */
-    public function getHost()
+    public function getHost(): ?string
     {
         return $this->host;
     }
@@ -674,7 +674,7 @@ class Connection
      * @return void
      * @throws ConnectionException
      */
-    public function sendAlive($timeout = 1.0)
+    public function sendAlive(float $timeout = 1.0)
     {
         if ($this->isConnected()) {
             $this->writeData(self::ALIVE, $timeout);

--- a/src/Network/Observer/AbstractBeats.php
+++ b/src/Network/Observer/AbstractBeats.php
@@ -87,7 +87,7 @@ abstract class AbstractBeats implements ConnectionObserver
      * @param integer $maximum agreement from client and server in milliseconds
      * @return float
      */
-    abstract protected function calculateInterval($maximum);
+    abstract protected function calculateInterval(int $maximum): float;
 
     /**
      * Called whenever a activity is detected that was issued by the client.
@@ -115,7 +115,7 @@ abstract class AbstractBeats implements ConnectionObserver
      *
      * @return bool
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return $this->enabled;
     }
@@ -125,7 +125,7 @@ abstract class AbstractBeats implements ConnectionObserver
      *
      * @return bool
      */
-    public function isDelayed()
+    public function isDelayed(): bool
     {
         if ($this->enabled && $this->lastbeat) {
             $now = microtime(true);
@@ -139,7 +139,7 @@ abstract class AbstractBeats implements ConnectionObserver
      *
      * @return null|float
      */
-    public function getInterval()
+    public function getInterval(): ?float
     {
         return $this->intervalUsed;
     }
@@ -172,7 +172,7 @@ abstract class AbstractBeats implements ConnectionObserver
      * @param Frame $frame
      * @return array
      */
-    private function getHeartbeats(Frame $frame)
+    private function getHeartbeats(Frame $frame): array
     {
         $beats = $frame['heart-beat'];
         if ($beats) {

--- a/src/Network/Observer/ConnectionObserverCollection.php
+++ b/src/Network/Observer/ConnectionObserverCollection.php
@@ -29,7 +29,7 @@ class ConnectionObserverCollection implements ConnectionObserver
      * @param ConnectionObserver $observer
      * @return ConnectionObserverCollection this collection
      */
-    public function addObserver(ConnectionObserver $observer)
+    public function addObserver(ConnectionObserver $observer): self
     {
         if (!in_array($observer, $this->observers, true)) {
             $this->observers[] = $observer;
@@ -43,7 +43,7 @@ class ConnectionObserverCollection implements ConnectionObserver
      * @param ConnectionObserver $observer
      * @return ConnectionObserverCollection this collection
      */
-    public function removeObserver(ConnectionObserver $observer)
+    public function removeObserver(ConnectionObserver $observer): self
     {
         $index = array_search($observer, $this->observers, true);
         if ($index !== false) {
@@ -57,7 +57,7 @@ class ConnectionObserverCollection implements ConnectionObserver
      *
      * @return ConnectionObserver[]
      */
-    public function getObservers()
+    public function getObservers(): array
     {
         return array_values($this->observers);
     }

--- a/src/Network/Observer/HeartbeatEmitter.php
+++ b/src/Network/Observer/HeartbeatEmitter.php
@@ -64,7 +64,7 @@ class HeartbeatEmitter extends AbstractBeats
      * @param Connection $connection
      * @param float $intervalUsage
      */
-    public function __construct(Connection $connection, $intervalUsage = 0.65)
+    public function __construct(Connection $connection, float $intervalUsage = 0.65)
     {
         $this->intervalUsage = max(0.05, min($intervalUsage, 0.95));
         $this->connection = $connection;
@@ -75,7 +75,7 @@ class HeartbeatEmitter extends AbstractBeats
      *
      * @param bool $pessimistic
      */
-    public function setPessimistic($pessimistic)
+    public function setPessimistic(bool $pessimistic)
     {
         $this->pessimistic = $pessimistic;
     }
@@ -118,11 +118,11 @@ class HeartbeatEmitter extends AbstractBeats
      * @param integer $maximum
      * @return float
      */
-    protected function calculateInterval($maximum)
+    protected function calculateInterval(int $maximum): float
     {
         $intervalUsed = $maximum * $this->intervalUsage;
         $this->assertReadTimeoutSufficient($intervalUsed);
-        return $intervalUsed;
+        return floatval($intervalUsed);
     }
 
     /**
@@ -131,7 +131,7 @@ class HeartbeatEmitter extends AbstractBeats
      * @param float $interval
      * @return void
      */
-    private function assertReadTimeoutSufficient($interval)
+    private function assertReadTimeoutSufficient(float $interval)
     {
         $readTimeout = $this->connection->getReadTimeout();
         $readTimeoutMs = ($readTimeout[0] * 1000) + ($readTimeout[1] / 1000);

--- a/src/Network/Observer/ServerAliveObserver.php
+++ b/src/Network/Observer/ServerAliveObserver.php
@@ -46,7 +46,7 @@ class ServerAliveObserver extends AbstractBeats
      *
      * @param float $intervalUsage 150% default
      */
-    public function __construct($intervalUsage = 1.5)
+    public function __construct(float $intervalUsage = 1.5)
     {
         $this->intervalUsage = max(1, $intervalUsage);
     }
@@ -99,8 +99,8 @@ class ServerAliveObserver extends AbstractBeats
     /**
      * @inheritdoc
      */
-    protected function calculateInterval($maximum)
+    protected function calculateInterval(int $maximum): float
     {
-        return $maximum * $this->intervalUsage;
+        return floatval($maximum * $this->intervalUsage);
     }
 }

--- a/src/Protocol/Protocol.php
+++ b/src/Protocol/Protocol.php
@@ -48,9 +48,9 @@ class Protocol
     /**
      * Setup stomp protocol with configuration.
      *
-     * @param string|null $clientId
-     * @param string $version
-     * @param string|null $server
+     * @param string|null $clientId A client ID.
+     * @param string $version The Stomp version to use.
+     * @param string|null $server The server identifying string.
      */
     public function __construct(?string $clientId, string $version = Version::VERSION_1_0, ?string $server = null)
     {
@@ -231,6 +231,7 @@ class Protocol
      * @return \Stomp\Transport\Frame The NACK frame.
      * @throws StompException If protocol using Stomp version 1.0
      * @throws \LogicException If requeue header specified (RabbitMQ specific NOT Stomp).
+     * TODO: Requeue is only for RabbitMQ and is not in Stomp spec, should be specific to that protocol.
      */
     public function getNackFrame(Frame $frame, ?string $transactionId = null, ?bool $requeue = null): Frame
     {

--- a/src/Protocol/Protocol.php
+++ b/src/Protocol/Protocol.php
@@ -212,13 +212,9 @@ class Protocol
         $ack = $this->createFrame('ACK');
         $ack['transaction'] = $transactionId;
         if ($this->hasVersion(Version::VERSION_1_2)) {
-            if (isset($frame['ack'])) {
-                $ack['id'] = $frame['ack'];
-            } else {
-                $ack['id'] = $frame->getMessageId();
-            }
+            $ack['id'] = $frame['id'] ?: $frame->getMessageId();
         } else {
-            $ack['message-id'] = $frame->getMessageId();
+            $ack['message-id'] = $frame['message-id'] ?: $frame->getMessageId();
             if ($this->hasVersion(Version::VERSION_1_1)) {
                 $ack['subscription'] = $frame['subscription'];
             }
@@ -247,15 +243,14 @@ class Protocol
         $nack = $this->createFrame('NACK');
         $nack['transaction'] = $transactionId;
         if ($this->hasVersion(Version::VERSION_1_2)) {
-            $nack['id'] = $frame->getMessageId();
+            $nack['id'] = $frame['id'] ?: $frame->getMessageId();
         } else {
-            $nack['message-id'] = $frame->getMessageId();
+            $nack['message-id'] = $frame['message-id'] ?: $frame->getMessageId();
             if ($this->hasVersion(Version::VERSION_1_1)) {
                 $nack['subscription'] = $frame['subscription'];
             }
         }
 
-        $nack['message-id'] = $frame->getMessageId();
         return $nack;
     }
 

--- a/src/Protocol/Version.php
+++ b/src/Protocol/Version.php
@@ -63,11 +63,11 @@ class Version
     /**
      * Returns the protocol to use.
      *
-     * @param string $clientId
+     * @param string|null $clientId
      * @param string $default server to use of no server detected
      * @return ActiveMq|Apollo|Protocol|RabbitMq
      */
-    public function getProtocol($clientId, $default = 'ActiveMQ/5.11.1')
+    public function getProtocol(?string $clientId, string $default = 'ActiveMQ/5.11.1'): Protocol
     {
         $server = trim((string) $this->frame['server']) ?: $default;
         $version = $this->getVersion();
@@ -91,7 +91,7 @@ class Version
      *
      * @return string
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->frame['version'] ?: self::VERSION_1_0;
     }
@@ -102,7 +102,7 @@ class Version
      * @param string $version to check against
      * @return boolean
      */
-    public function hasVersion($version)
+    public function hasVersion(string $version): bool
     {
         return version_compare($this->getVersion(), $version, '>=');
     }

--- a/src/StatefulStomp.php
+++ b/src/StatefulStomp.php
@@ -80,7 +80,7 @@ class StatefulStomp extends StateSetter implements IStateful
      * @param \Stomp\Transport\Message $message
      * @return bool
      */
-    public function send($destination, Message $message)
+    public function send(string $destination, Message $message): bool
     {
         return $this->state->send($destination, $message);
     }
@@ -126,7 +126,7 @@ class StatefulStomp extends StateSetter implements IStateful
      * @param array $header
      * @return int
      */
-    public function subscribe($destination, $selector = null, $ack = 'auto', array $header = [])
+    public function subscribe(string $destination, $selector = null, string $ack = 'auto', array $header = []): int
     {
         return $this->state->subscribe($destination, $selector, $ack, $header);
     }
@@ -137,7 +137,7 @@ class StatefulStomp extends StateSetter implements IStateful
      * @param int $subscriptionId
      * @return void
      */
-    public function unsubscribe($subscriptionId = null)
+    public function unsubscribe(int $subscriptionId = null)
     {
         $this->state->unsubscribe($subscriptionId);
     }
@@ -147,7 +147,7 @@ class StatefulStomp extends StateSetter implements IStateful
      *
      * @return SubscriptionList
      */
-    public function getSubscriptions()
+    public function getSubscriptions(): SubscriptionList
     {
         return $this->state->getSubscriptions();
     }

--- a/src/StatefulStomp.php
+++ b/src/StatefulStomp.php
@@ -124,9 +124,9 @@ class StatefulStomp extends StateSetter implements IStateful
      * @param string $selector
      * @param string $ack
      * @param array $header
-     * @return int
+     * @return string The subscription id.
      */
-    public function subscribe(string $destination, $selector = null, string $ack = 'auto', array $header = []): int
+    public function subscribe(string $destination, $selector = null, string $ack = 'auto', array $header = []): string
     {
         return $this->state->subscribe($destination, $selector, $ack, $header);
     }
@@ -134,10 +134,10 @@ class StatefulStomp extends StateSetter implements IStateful
     /**
      * Unsubscribe from current or given destination.
      *
-     * @param int $subscriptionId
+     * @param string $subscriptionId
      * @return void
      */
-    public function unsubscribe(int $subscriptionId = null)
+    public function unsubscribe(string $subscriptionId = null)
     {
         $this->state->unsubscribe($subscriptionId);
     }

--- a/src/States/ConsumerState.php
+++ b/src/States/ConsumerState.php
@@ -102,7 +102,7 @@ class ConsumerState extends StateTemplate
     /**
      * @inheritdoc
      */
-    public function subscribe($destination, $selector, $ack, array $header = []): int
+    public function subscribe($destination, $selector, $ack, array $header = []): string
     {
         $subscription = new Subscription($destination, $selector, $ack, IdGenerator::generateId(), $header);
         $this->getClient()->sendFrame(

--- a/src/States/ConsumerState.php
+++ b/src/States/ConsumerState.php
@@ -86,7 +86,7 @@ class ConsumerState extends StateTemplate
     /**
      * @inheritdoc
      */
-    public function send($destination, Message $message)
+    public function send(string $destination, Message $message): bool
     {
         return $this->getClient()->send($destination, $message);
     }
@@ -102,7 +102,7 @@ class ConsumerState extends StateTemplate
     /**
      * @inheritdoc
      */
-    public function subscribe($destination, $selector, $ack, array $header = [])
+    public function subscribe($destination, $selector, $ack, array $header = []): int
     {
         $subscription = new Subscription($destination, $selector, $ack, IdGenerator::generateId(), $header);
         $this->getClient()->sendFrame(
@@ -134,10 +134,10 @@ class ConsumerState extends StateTemplate
     /**
      * Closes given subscription or last opened.
      *
-     * @param string $subscriptionId
+     * @param string|null $subscriptionId
      * @return bool true if last one was closed
      */
-    protected function endSubscription($subscriptionId = null)
+    protected function endSubscription(?string $subscriptionId = null): bool
     {
         if (!$subscriptionId) {
             $subscriptionId = $this->subscriptions->getLast()->getSubscriptionId();
@@ -173,7 +173,7 @@ class ConsumerState extends StateTemplate
     /**
      * @inheritdoc
      */
-    public function getSubscriptions()
+    public function getSubscriptions(): SubscriptionList
     {
         return $this->subscriptions;
     }
@@ -182,7 +182,7 @@ class ConsumerState extends StateTemplate
     /**
      * @inheritdoc
      */
-    protected function getOptions()
+    protected function getOptions(): array
     {
         return [
             'subscriptions' => $this->subscriptions

--- a/src/States/IStateful.php
+++ b/src/States/IStateful.php
@@ -75,17 +75,17 @@ interface IStateful
      * @param string|null $selector
      * @param string $ack
      * @param array  $header
-     * @return int
+     * @return string The subscription ID.
      */
-    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): int;
+    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): string;
 
     /**
      * Unsubscribe from current or given destination.
      *
-     * @param int $subscriptionId
+     * @param string|null $subscriptionId
      * @return void
      */
-    public function unsubscribe(int $subscriptionId = null);
+    public function unsubscribe(string $subscriptionId = null);
 
 
     /**

--- a/src/States/IStateful.php
+++ b/src/States/IStateful.php
@@ -34,7 +34,7 @@ interface IStateful
      * @param bool $requeue Requeue header not supported on all brokers
      * @return void
      */
-    public function nack(Frame $frame, $requeue = null);
+    public function nack(Frame $frame, ?bool $requeue = null);
 
     /**
      * Send a message.
@@ -43,7 +43,7 @@ interface IStateful
      * @param \Stomp\Transport\Message $message
      * @return bool
      */
-    public function send($destination, Message $message);
+    public function send(string $destination, Message $message): bool;
 
     /**
      * Begins an transaction.
@@ -72,12 +72,12 @@ interface IStateful
      * Returns the subscriptionId used for this.
      *
      * @param string $destination
-     * @param string $selector
+     * @param string|null $selector
      * @param string $ack
      * @param array  $header
      * @return int
      */
-    public function subscribe($destination, $selector, $ack, array $header = []);
+    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): int;
 
     /**
      * Unsubscribe from current or given destination.
@@ -85,7 +85,7 @@ interface IStateful
      * @param int $subscriptionId
      * @return void
      */
-    public function unsubscribe($subscriptionId = null);
+    public function unsubscribe(int $subscriptionId = null);
 
 
     /**
@@ -100,5 +100,5 @@ interface IStateful
      *
      * @return SubscriptionList
      */
-    public function getSubscriptions();
+    public function getSubscriptions(): SubscriptionList;
 }

--- a/src/States/Meta/Subscription.php
+++ b/src/States/Meta/Subscription.php
@@ -51,8 +51,13 @@ class Subscription
      * @param int $subscriptionId
      * @param array $header additionally passed to create this subscription
      */
-    public function __construct($destination, $selector, $ack, $subscriptionId, array $header = [])
-    {
+    public function __construct(
+        string $destination,
+        ?string $selector,
+        string $ack,
+        ?int $subscriptionId,
+        array $header = []
+    ) {
         $this->subscriptionId = $subscriptionId;
         $this->selector = $selector;
         $this->destination = $destination;
@@ -64,7 +69,7 @@ class Subscription
     /**
      * @return int
      */
-    public function getSubscriptionId()
+    public function getSubscriptionId(): int
     {
         return $this->subscriptionId;
     }
@@ -72,7 +77,7 @@ class Subscription
     /**
      * @return String
      */
-    public function getSelector()
+    public function getSelector(): ?string
     {
         return $this->selector;
     }
@@ -80,7 +85,7 @@ class Subscription
     /**
      * @return String
      */
-    public function getDestination()
+    public function getDestination(): ?string
     {
         return $this->destination;
     }
@@ -88,7 +93,7 @@ class Subscription
     /**
      * @return String
      */
-    public function getAck()
+    public function getAck(): string
     {
         return $this->ack;
     }
@@ -96,7 +101,7 @@ class Subscription
     /**
      * @return array
      */
-    public function getHeader()
+    public function getHeader(): array
     {
         return $this->header;
     }
@@ -107,7 +112,7 @@ class Subscription
      * @param Frame $frame
      * @return bool
      */
-    public function belongsTo(Frame $frame)
+    public function belongsTo(Frame $frame): bool
     {
         return ($frame['subscription'] == $this->subscriptionId);
     }

--- a/src/States/Meta/Subscription.php
+++ b/src/States/Meta/Subscription.php
@@ -19,7 +19,7 @@ use Stomp\Transport\Frame;
 class Subscription
 {
     /**
-     * @var int
+     * @var string
      */
     private $subscriptionId;
 
@@ -46,16 +46,16 @@ class Subscription
     /**
      * Subscription constructor.
      * @param String $destination
-     * @param String $selector
+     * @param String|null $selector
      * @param String $ack
-     * @param int $subscriptionId
+     * @param string|null $subscriptionId
      * @param array $header additionally passed to create this subscription
      */
     public function __construct(
         string $destination,
         ?string $selector,
         string $ack,
-        ?int $subscriptionId,
+        ?string $subscriptionId,
         array $header = []
     ) {
         $this->subscriptionId = $subscriptionId;
@@ -67,9 +67,9 @@ class Subscription
 
 
     /**
-     * @return int
+     * @return string
      */
-    public function getSubscriptionId(): int
+    public function getSubscriptionId(): string
     {
         return $this->subscriptionId;
     }

--- a/src/States/Meta/SubscriptionList.php
+++ b/src/States/Meta/SubscriptionList.php
@@ -33,7 +33,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return Subscription
      */
-    public function getLast()
+    public function getLast(): Subscription
     {
         return end($this->subscriptions);
     }
@@ -57,21 +57,17 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * @inheritdoc
      *
-     * @return \Iterator|Subscription[]
+     * @return \ArrayIterator|Subscription[]
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->subscriptions);
     }
 
     /**
      * @inheritdoc
-     *
-     * @return bool
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->subscriptions[$offset]);
     }
@@ -81,8 +77,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return Subscription
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): Subscription
     {
         return $this->subscriptions[$offset];
     }
@@ -90,8 +85,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * @inheritdoc
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->subscriptions[$offset] = $value;
     }
@@ -99,8 +93,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * @inheritdoc
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->subscriptions[$offset]);
     }
@@ -108,8 +101,7 @@ class SubscriptionList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * @inheritdoc
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->subscriptions);
     }

--- a/src/States/ProducerState.php
+++ b/src/States/ProducerState.php
@@ -35,7 +35,7 @@ class ProducerState extends StateTemplate
     /**
      * @inheritdoc
      */
-    public function subscribe($destination, $selector, $ack, array $header = [])
+    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): int
     {
         return $this->setState(
             new ConsumerState($this->getClient(), $this->getBase()),
@@ -46,7 +46,7 @@ class ProducerState extends StateTemplate
     /**
      * @inheritdoc
      */
-    protected function getOptions()
+    protected function getOptions(): array
     {
         return [];
     }

--- a/src/States/ProducerState.php
+++ b/src/States/ProducerState.php
@@ -35,7 +35,7 @@ class ProducerState extends StateTemplate
     /**
      * @inheritdoc
      */
-    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): int
+    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): string
     {
         return $this->setState(
             new ConsumerState($this->getClient(), $this->getBase()),

--- a/src/States/ProducerTransactionState.php
+++ b/src/States/ProducerTransactionState.php
@@ -50,7 +50,7 @@ class ProducerTransactionState extends ProducerState
     /**
      * @inheritdoc
      */
-    public function subscribe($destination, $selector, $ack, array $header = [])
+    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): int
     {
         return $this->setState(
             new ConsumerTransactionState($this->getClient(), $this->getBase()),

--- a/src/States/ProducerTransactionState.php
+++ b/src/States/ProducerTransactionState.php
@@ -50,7 +50,7 @@ class ProducerTransactionState extends ProducerState
     /**
      * @inheritdoc
      */
-    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): int
+    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): string
     {
         return $this->setState(
             new ConsumerTransactionState($this->getClient(), $this->getBase()),

--- a/src/States/StateTemplate.php
+++ b/src/States/StateTemplate.php
@@ -52,7 +52,7 @@ abstract class StateTemplate extends StateSetter implements IStateful
      *
      * @return StatefulStomp
      */
-    protected function getBase()
+    protected function getBase(): StatefulStomp
     {
         return $this->base;
     }
@@ -70,12 +70,12 @@ abstract class StateTemplate extends StateSetter implements IStateful
      *
      * @return array
      */
-    abstract protected function getOptions();
+    abstract protected function getOptions(): array;
 
     /**
      * @return Client
      */
-    protected function getClient()
+    protected function getClient(): Client
     {
         return $this->client;
     }
@@ -83,7 +83,7 @@ abstract class StateTemplate extends StateSetter implements IStateful
     /**
      * @return Protocol
      */
-    protected function getProtocol()
+    protected function getProtocol(): Protocol
     {
         return $this->client->getProtocol();
     }
@@ -120,7 +120,7 @@ abstract class StateTemplate extends StateSetter implements IStateful
     /**
      * @inheritdoc
      */
-    public function send($destination, Message $message)
+    public function send(string $destination, Message $message): bool
     {
         return $this->getClient()->send($destination, $message);
     }
@@ -152,7 +152,7 @@ abstract class StateTemplate extends StateSetter implements IStateful
     /**
      * @inheritdoc
      */
-    public function subscribe($destination, $selector, $ack, array $header = [])
+    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): int
     {
         throw new InvalidStateException($this, __FUNCTION__);
     }
@@ -176,7 +176,7 @@ abstract class StateTemplate extends StateSetter implements IStateful
     /**
      * @inheritdoc
      */
-    public function getSubscriptions()
+    public function getSubscriptions(): SubscriptionList
     {
         return new SubscriptionList();
     }

--- a/src/States/StateTemplate.php
+++ b/src/States/StateTemplate.php
@@ -152,7 +152,7 @@ abstract class StateTemplate extends StateSetter implements IStateful
     /**
      * @inheritdoc
      */
-    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): int
+    public function subscribe(string $destination, ?string $selector, string $ack, array $header = []): string
     {
         throw new InvalidStateException($this, __FUNCTION__);
     }

--- a/src/States/TransactionsTrait.php
+++ b/src/States/TransactionsTrait.php
@@ -25,13 +25,13 @@ trait TransactionsTrait
     /**
      * @return Protocol
      */
-    abstract public function getProtocol();
+    abstract public function getProtocol(): Protocol;
 
 
     /**
      * @return Client
      */
-    abstract public function getClient();
+    abstract public function getClient(): Client;
 
     /**
      * Id used for current transaction.
@@ -62,7 +62,7 @@ trait TransactionsTrait
      *
      * @return array
      */
-    protected function getOptions()
+    protected function getOptions(): array
     {
         return ['transactionId' => $this->transactionId];
     }
@@ -74,7 +74,7 @@ trait TransactionsTrait
      * @param \Stomp\Transport\Message $message
      * @return bool
      */
-    public function send($destination, Message $message)
+    public function send(string $destination, Message $message): bool
     {
         return $this->getClient()->send($destination, $message, ['transaction' => $this->transactionId], false);
     }

--- a/src/Transport/Bytes.php
+++ b/src/Transport/Bytes.php
@@ -32,7 +32,7 @@ class Bytes extends Message
     /**
      * @inheritdoc
      */
-    protected function getBodySize()
+    protected function getBodySize(): int
     {
         return count(unpack('c*', $this->getBody()));
     }

--- a/src/Transport/Frame.php
+++ b/src/Transport/Frame.php
@@ -75,7 +75,7 @@ class Frame implements ArrayAccess
      * @param array $header
      * @return Frame
      */
-    public function addHeaders(array $header)
+    public function addHeaders(array $header): self
     {
         $this->headers += $header;
         return $this;
@@ -86,9 +86,17 @@ class Frame implements ArrayAccess
      *
      * @return string
      */
-    public function getMessageId()
+    public function getMessageId(): string
     {
+        if (!isset($this['message-id'])) {
+            $this['message-id'] = $this->uuid();
+        }
         return $this['message-id'];
+    }
+
+    private function uuid(): string
+    {
+        return bin2hex(random_bytes(20));
     }
 
     /**
@@ -96,7 +104,7 @@ class Frame implements ArrayAccess
      *
      * @return boolean
      */
-    public function isErrorFrame()
+    public function isErrorFrame(): bool
     {
         return ($this->command == 'ERROR');
     }
@@ -104,9 +112,9 @@ class Frame implements ArrayAccess
     /**
      * Tell the frame that we expect an length header.
      *
-     * @param bool|false $expected
+     * @param bool $expected
      */
-    public function expectLengthHeader($expected = false)
+    public function expectLengthHeader(bool $expected = false)
     {
         $this->addLengthHeader = $expected;
     }
@@ -114,9 +122,9 @@ class Frame implements ArrayAccess
     /**
      * Enable legacy mode for this frame
      *
-     * @param bool|false $legacy
+     * @param bool $legacy
      */
-    public function legacyMode($legacy = false)
+    public function legacyMode(bool $legacy = false)
     {
         $this->legacyMode = $legacy;
     }
@@ -126,7 +134,7 @@ class Frame implements ArrayAccess
      *
      * @return bool
      */
-    public function isLegacyMode()
+    public function isLegacyMode(): bool
     {
         return $this->legacyMode;
     }
@@ -136,7 +144,7 @@ class Frame implements ArrayAccess
      *
      * @return string
      */
-    public function getCommand()
+    public function getCommand(): string
     {
         return $this->command;
     }
@@ -146,7 +154,7 @@ class Frame implements ArrayAccess
      *
      * @return string
      */
-    public function getBody()
+    public function getBody(): string
     {
         return $this->body;
     }
@@ -156,7 +164,7 @@ class Frame implements ArrayAccess
      *
      * @return array
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
@@ -190,7 +198,7 @@ class Frame implements ArrayAccess
      *
      * @return int
      */
-    protected function getBodySize()
+    protected function getBodySize(): int
     {
         return strlen($this->body);
     }
@@ -201,7 +209,7 @@ class Frame implements ArrayAccess
      * @param string $value
      * @return string
      */
-    protected function encodeHeaderValue($value)
+    protected function encodeHeaderValue(string $value): string
     {
         if ($this->legacyMode) {
             return str_replace(["\n"], ['\n'], $value);
@@ -212,8 +220,7 @@ class Frame implements ArrayAccess
     /**
      * @inheritdoc
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->headers[$offset]);
     }
@@ -233,8 +240,7 @@ class Frame implements ArrayAccess
     /**
      * @inheritdoc
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ($value !== null) {
             $this->headers[$offset] = $value;
@@ -245,8 +251,7 @@ class Frame implements ArrayAccess
     /**
      * @inheritdoc
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->headers[$offset]);
     }

--- a/src/Transport/Frame.php
+++ b/src/Transport/Frame.php
@@ -86,17 +86,13 @@ class Frame implements ArrayAccess
      *
      * @return string
      */
-    public function getMessageId(): string
+    public function getMessageId(): ?string
     {
-        if (!isset($this['message-id'])) {
-            $this['message-id'] = $this->uuid();
+        if ($this->isLegacyMode()) {
+            return $this['message-id'];
+        } else {
+            return $this['id'] ?? $this['message-id'];
         }
-        return $this['message-id'];
-    }
-
-    private function uuid(): string
-    {
-        return bin2hex(random_bytes(20));
     }
 
     /**

--- a/src/Transport/FrameFactory.php
+++ b/src/Transport/FrameFactory.php
@@ -46,7 +46,7 @@ class FrameFactory
      * @param boolean $legacyMode stomp 1.0 mode (headers)
      * @return Frame
      */
-    public function createFrame($command, array $headers, $body, $legacyMode)
+    public function createFrame($command, array $headers, $body, $legacyMode): Frame
     {
         foreach ($this->resolver as $resolver) {
             if ($frame = $resolver($command, $headers, $body, $legacyMode)) {
@@ -65,7 +65,7 @@ class FrameFactory
      * @param boolean $legacyMode
      * @return Frame
      */
-    private function defaultFrame($command, array $headers, $body, $legacyMode)
+    private function defaultFrame($command, array $headers, $body, $legacyMode): Frame
     {
         $frame = new Frame($command, $headers, $body);
         $frame->legacyMode($legacyMode);
@@ -81,7 +81,7 @@ class FrameFactory
      * @param callable $callable
      * @return FrameFactory
      */
-    public function registerResolver($callable)
+    public function registerResolver($callable): FrameFactory
     {
         array_unshift($this->resolver, $callable);
         return $this;

--- a/src/Transport/Parser.php
+++ b/src/Transport/Parser.php
@@ -124,9 +124,9 @@ class Parser
     /**
      * Parser constructor.
      *
-     * @param FrameFactory $factory
+     * @param FrameFactory|null $factory
      */
-    public function __construct(FrameFactory $factory = null)
+    public function __construct(?FrameFactory $factory = null)
     {
         $this->factory = $factory ?: new FrameFactory();
     }
@@ -137,7 +137,7 @@ class Parser
      * @param ConnectionObserver $observer
      * @return Parser
      */
-    public function setObserver(ConnectionObserver $observer)
+    public function setObserver(ConnectionObserver $observer): self
     {
         $this->observer = $observer;
         return $this;
@@ -149,7 +149,7 @@ class Parser
      *
      * @return FrameFactory
      */
-    public function getFactory()
+    public function getFactory(): ?FrameFactory
     {
         return $this->factory;
     }
@@ -157,9 +157,9 @@ class Parser
     /**
      * Set parser in legacy mode.
      *
-     * @param bool|false $legacy
+     * @param bool $legacy
      */
-    public function legacyMode($legacy = false)
+    public function legacyMode(bool $legacy = false)
     {
         $this->legacyMode = $legacy;
     }
@@ -170,7 +170,7 @@ class Parser
      * @param string $data
      * @return void
      */
-    public function addData($data)
+    public function addData(string $data)
     {
         $this->buffer .= $data;
     }
@@ -181,7 +181,7 @@ class Parser
      * @deprecated Will be removed in next version. Please use nextFrame().
      * @return Frame
      */
-    public function getFrame()
+    public function getFrame(): Frame
     {
         return $this->frame;
     }
@@ -191,7 +191,7 @@ class Parser
      *
      * @return null|Frame
      */
-    public function nextFrame()
+    public function nextFrame(): ?Frame
     {
         if ($this->parse()) {
             $frame = $this->getFrame();
@@ -212,7 +212,7 @@ class Parser
      *
      * @return bool
      */
-    public function parse()
+    public function parse(): bool
     {
         if ($this->buffer === '') {
             return false;
@@ -269,7 +269,7 @@ class Parser
      *
      * @return bool
      */
-    private function detectFrameHead()
+    private function detectFrameHead(): bool
     {
         $firstCrLf = strpos($this->buffer, self::HEADER_STOP_CR_LF, $this->offset);
         $firstLf = strpos($this->buffer, self::HEADER_STOP_LF, $this->offset);
@@ -294,7 +294,7 @@ class Parser
      *
      * @return bool
      */
-    private function detectFrameEnd()
+    private function detectFrameEnd(): bool
     {
         $bodySize = null;
         if ($this->expectedBodyLength) {
@@ -318,7 +318,7 @@ class Parser
      *
      * @param integer $bodySize
      */
-    private function setFrame($bodySize)
+    private function setFrame(int $bodySize)
     {
         $this->frame = $this->factory->createFrame(
             $this->command,
@@ -339,7 +339,7 @@ class Parser
      * @param string $source
      * @return void
      */
-    private function extractFrameMeta($source)
+    private function extractFrameMeta(string $source)
     {
         $headers = preg_split("/(\r?\n)+/", $source);
 
@@ -365,7 +365,7 @@ class Parser
      * @param string $value
      * @return string
      */
-    private function decodeHeaderValue($value)
+    private function decodeHeaderValue(string $value): string
     {
         if ($this->legacyMode) {
             return str_replace(['\n'], ["\n"], $value);
@@ -378,7 +378,7 @@ class Parser
      *
      * @return string
      */
-    public function flushBuffer()
+    public function flushBuffer(): string
     {
         $this->expectedBodyLength = null;
         $this->headers = [];

--- a/tests/Functional/Generic/ConnectionTest.php
+++ b/tests/Functional/Generic/ConnectionTest.php
@@ -134,7 +134,10 @@ class ConnectionTest extends TestCase
             $connection->readFrame();
             $this->fail('Expected a exception!');
         } catch (ConnectionException $exception) {
-            $this->assertStringContainsString('Check failed to determine if the socket is readable', $exception->getMessage());
+            $this->assertStringContainsString(
+                'Check failed to determine if the socket is readable',
+                $exception->getMessage()
+            );
         } catch (\ValueError $exception) {
             $this->assertStringContainsString(
                 'No stream arrays were passed',

--- a/tests/Unit/Broker/Apollo/ApolloTest.php
+++ b/tests/Unit/Broker/Apollo/ApolloTest.php
@@ -59,6 +59,9 @@ class ApolloTest extends ProtocolTestCase
         $this->assertIsUnsubscribeFrame($result);
     }
 
+    /**
+     * TODO: There is no NACK in Stomp version 1.0, so this is testing code that is in violation of the spec?
+     */
     public function testNackVersionZero()
     {
         $instance = $this->getProtocol(Version::VERSION_1_0);

--- a/tests/Unit/Network/Observer/AbstractBeatsTest.php
+++ b/tests/Unit/Network/Observer/AbstractBeatsTest.php
@@ -208,7 +208,7 @@ class AbstractBeatsTest extends TestCase
             );
         $instance->expects($this->once())
             ->method('calculateInterval')
-            ->willReturn(max($intervalClient, $intervalClient));
+            ->willReturn(floatval(max($intervalClient, $intervalClient)));
     }
 
     /**

--- a/tests/Unit/Protocol/ProtocolTestCase.php
+++ b/tests/Unit/Protocol/ProtocolTestCase.php
@@ -90,11 +90,11 @@ abstract class ProtocolTestCase extends TestCase
         $instance = $this->getProtocol(Version::VERSION_1_2);
 
         $actual = $instance->getAckFrame(
-            new Frame(null, ['message-id' => 'id-value', 'ack' => 'ack-id-value']),
+            new Frame(null, ['id' => 'id-value', 'ack' => 'ack-id-value']),
             'my-transaction'
         );
         $this->assertIsAckFrame($actual);
-        $this->assertEquals('ack-id-value', $actual['id']);
+        $this->assertEquals('id-value', $actual['id']);
         $this->assertEquals('my-transaction', $actual['transaction']);
     }
 

--- a/tests/Unit/Protocol/ProtocolTestCase.php
+++ b/tests/Unit/Protocol/ProtocolTestCase.php
@@ -90,7 +90,7 @@ abstract class ProtocolTestCase extends TestCase
         $instance = $this->getProtocol(Version::VERSION_1_2);
 
         $actual = $instance->getAckFrame(
-            new Frame(null, ['id' => 'id-value', 'ack' => 'ack-id-value']),
+            new Frame(null, ['id' => 'id-value', 'ack' => 'id-value']),
             'my-transaction'
         );
         $this->assertIsAckFrame($actual);
@@ -121,7 +121,10 @@ abstract class ProtocolTestCase extends TestCase
     {
         $instance = $this->getProtocol(Version::VERSION_1_2);
 
-        $actual = $instance->getNackFrame(new Frame(null, ['message-id' => 'id-value']), 'my-transaction');
+        $actual = $instance->getNackFrame(
+            new Frame(null, ['message-id' => 'id-value', 'ack' => 'id-value']),
+            'my-transaction'
+        );
         $this->assertIsNackFrame($actual);
         $this->assertEquals('id-value', $actual['id']);
         $this->assertEquals('my-transaction', $actual['transaction']);

--- a/tests/Unit/SimpleStompTest.php
+++ b/tests/Unit/SimpleStompTest.php
@@ -119,8 +119,8 @@ class SimpleStompTest extends TestCase
             ],
             'nack' => [
                 'nack',
-                [new Frame('MESSAGE', ['ack' => 212])],
-                [$protocol->getNackFrame(new Frame('MESSAGE', ['ack' => 212])), false],
+                [new Frame('MESSAGE', ['id' => 212])],
+                [$protocol->getNackFrame(new Frame('MESSAGE', ['id' => 212])), false],
                 null
             ]
         ];


### PR DESCRIPTION
This is to add some documentation (as I understand it) and types to arguments and functions. 

This should have no impact on the code...except possibly for ACK/NACK. 

It appears that Apollo sends a "ack" header on MESSAGE frames which is not part of the spec. That seems to have impacted the base `Protocol` class which was looking for this `ack` header in the `Protocol::getAckFrame` function. 

Also but unrelated the in `Protocol::getNackFrame` a `message-id` header was being sent on all "nack" messages and was overwriting what may have been set previously.