### PR TITLE
support eclipse openmq

### DIFF
--- a/src/Protocol/Version.php
+++ b/src/Protocol/Version.php
@@ -80,7 +80,7 @@ class Version
         if (stristr($server, 'activemq') !== false) {
             return new ActiveMq($clientId, $version, $server);
         }
-        if (stristr($server, 'open message queue') !== false) {
+        if (stristr($server, 'open message queue') !== false || stristr($server, 'openmq') !== false) {
             return new OpenMq($clientId, $version, $server);
         }
         return new Protocol($clientId, $version, $server);


### PR DESCRIPTION
the client cannot currently identify the Eclipse OpenMQ(tm) server as OpenMQ and then uses the standard protocol

dump of the `CONNECTED` frame
```
"""
^ Stomp\Transport\Frame^ {#141
  #command: "CONNECTED"
  #headers: array:4 [
    "session" => "4787207378087646720[null]"
    "version" => "1.0"
    "heart-beat" => "0,0"
    "server" => "Eclipse OpenMQ(tm)"
  ]
  +body: ""
  -addLengthHeader: false
  -legacyMode: true
}
```