### PR TITLE
PHP 8.4 compatability: fix Implicitly marking parameter as nullable

### DIFF
--- a/src/Exception/ConnectionException.php
+++ b/src/Exception/ConnectionException.php
@@ -30,7 +30,7 @@ class ConnectionException extends StompException
      * @param array $connection
      * @param ConnectionException $previous
      */
-    public function __construct($info, array $connection = [], ConnectionException $previous = null)
+    public function __construct($info, array $connection = [], ?ConnectionException $previous = null)
     {
         $this->connectionInfo = $connection;
 

--- a/src/Network/Observer/Exception/HeartbeatException.php
+++ b/src/Network/Observer/Exception/HeartbeatException.php
@@ -22,7 +22,7 @@ class HeartbeatException extends \RuntimeException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message, \Exception $previous = null)
+    public function __construct($message, ?\Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/src/Transport/Parser.php
+++ b/src/Transport/Parser.php
@@ -126,7 +126,7 @@ class Parser
      *
      * @param FrameFactory $factory
      */
-    public function __construct(FrameFactory $factory = null)
+    public function __construct(?FrameFactory $factory = null)
     {
         $this->factory = $factory ?: new FrameFactory();
     }


### PR DESCRIPTION
This PR fixes deprection warnings in php8.4 like: 

Stomp\Transport\Parser::__construct(): Implicitly marking parameter $factory as nullable is deprecated, the explicit nullable type must be used instead
