### PR TITLE
Fixes memory problem of getBodySize when provided with large BodySize

### DIFF
--- a/src/Transport/Bytes.php
+++ b/src/Transport/Bytes.php
@@ -34,6 +34,6 @@ class Bytes extends Message
      */
     protected function getBodySize()
     {
-        return count(unpack('c*', $this->getBody()));
+        return ini_get('mbstring.func_overload') ? mb_strlen($this->getBody(), '8bit') : strlen($this->getBody());
     }
 }


### PR DESCRIPTION
An alternate way of calculating the `BodySize`, using less memory.